### PR TITLE
Add Backup Job API and Queue Handler for Chat Backups

### DIFF
--- a/backup-queue/package.json
+++ b/backup-queue/package.json
@@ -1,0 +1,20 @@
+{
+	"name": "backup-queue",
+	"version": "1.0.0",
+	"description": "",
+	"main": "index.js",
+	"scripts": {
+		"build": "tsc",
+		"dev": "wrangler dev",
+		"deploy": "wrangler publish",
+		"test": "vitest run"
+	},
+	"keywords": [],
+	"author": "",
+	"license": "ISC",
+	"dependencies": {
+		"@cloudflare/workers-types": "^4.20250413.0",
+		"typescript": "^5.8.3",
+		"wrangler": "^4.6.0"
+	}
+}

--- a/backup-queue/src/index.ts
+++ b/backup-queue/src/index.ts
@@ -1,0 +1,85 @@
+import type { BackupRequest, Env, BackupJob } from './types'
+import { BackupStatus } from './types'
+
+export default {
+	async fetch(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+		const url = new URL(request.url)
+
+		if (request.method === 'OPTIONS') {
+			return handleCors()
+		}
+
+		if (url.pathname === '/api/backup' && request.method === 'POST') {
+			return handleBackupRequest(request, env, ctx)
+		}
+
+		return new Response('Not found', { status: 404 })
+	},
+
+	async queue(batch: MessageBatch<BackupJob>, env: Env): Promise<void> {
+		for (const message of batch.messages) {
+			const job = message.body
+			try {
+				console.info(`Processing backup job ${job.backupId} for chat ${job.chatId}`)
+				//TODO: Forward the backup job to another worker for processing with a maximum TTL
+			} catch (error) {
+				console.error(`Error processing backup job ${job.backupId}:`, error)
+			}
+		}
+	},
+}
+
+async function handleBackupRequest(request: Request, env: Env, ctx: ExecutionContext): Promise<Response> {
+	try {
+		const data = (await request.json()) as BackupRequest
+		if (!data.chatId || !data.userId) {
+			return new Response(JSON.stringify({ error: 'Missing required fields' }), {
+				status: 400,
+				headers: corsHeaders(),
+			})
+		}
+
+		const backupId = crypto.randomUUID()
+
+		await env.BACKUP_QUEUE.send({
+			backupId,
+			chatId: data.chatId,
+			userId: data.userId,
+			timestamp: new Date().toISOString(),
+		})
+
+		return new Response(
+			JSON.stringify({
+				backupId,
+				status: BackupStatus.PENDING,
+				message: 'Backup job queued successfully',
+			}),
+			{
+				status: 200,
+				headers: corsHeaders(),
+			},
+		)
+	} catch (error) {
+		console.error('Error processing backup request:', error)
+		return new Response(JSON.stringify({ error: 'Failed to process backup request' }), {
+			status: 500,
+			headers: corsHeaders(),
+		})
+	}
+}
+
+function handleCors(): Response {
+	return new Response(null, {
+		status: 204,
+		headers: corsHeaders(),
+	})
+}
+
+function corsHeaders(): HeadersInit {
+	return {
+		'Access-Control-Allow-Origin': '*',
+		'Access-Control-Allow-Methods': 'GET, POST, OPTIONS',
+		'Access-Control-Allow-Headers': 'Content-Type',
+		'Content-Type': 'application/json',
+	}
+}

--- a/backup-queue/src/types.ts
+++ b/backup-queue/src/types.ts
@@ -1,0 +1,29 @@
+export interface BackupRequest {
+	userId: string
+	chatId: string
+	options?: {
+		includeMedia?: boolean
+		dateRange?: {
+			start: string
+			end: string
+		}
+	}
+}
+
+export enum BackupStatus {
+	PENDING = 'pending',
+	PROCESSING = 'processing',
+	SUCCESS = 'success',
+	FAILED = 'failed',
+}
+
+export interface Env {
+	BACKUP_QUEUE: Queue
+}
+
+export interface BackupJob {
+	backupId: string
+	chatId: string
+	userId: string
+	timestamp: string
+}

--- a/backup-queue/tsconfig.json
+++ b/backup-queue/tsconfig.json
@@ -1,0 +1,19 @@
+{
+    "compilerOptions": {
+      "target": "ES2020",
+      "module": "CommonJS",
+      "lib": ["ES2020"],
+      "types": ["@cloudflare/workers-types", "node"],
+      "moduleResolution": "node",
+      "strict": true,
+      "noImplicitAny": true,
+      "strictNullChecks": true,
+      "outDir": "dist",
+      "esModuleInterop": true,
+      "skipLibCheck": true,
+      "forceConsistentCasingInFileNames": true
+    },
+    "include": ["src"],
+    "exclude": ["node_modules"]
+  }
+  

--- a/backup-queue/wrangler.toml
+++ b/backup-queue/wrangler.toml
@@ -1,0 +1,18 @@
+name = "backup-queue"
+main = "src/index.ts"
+compatibility_date = "2023-12-01"
+
+[[queues.producers]]
+queue = "backup-queue"
+binding = "BACKUP_QUEUE"
+
+[[queues.consumers]]
+queue = "backup-queue"
+max_batch_size = 10
+max_batch_timeout = 30
+max_retries = 3
+
+[vars]
+STORAGE_PATH = "./storage"
+MONGODB_URI = "mongodb://localhost:27017"
+MONGODB_DB = "telegram_backups"


### PR DESCRIPTION
### 📌 Description
Added a Cloudflare Worker with HTTP and Queue support for handling chat backup jobs.

### 🛠 Changes Made
- Implemented `fetch` handler to accept `/api/backup` POST requests.
- Added `OPTIONS` method support for CORS preflight.
- Introduced `handleBackupRequest` to queue backup jobs.
- Implemented `queue` consumer to log and forward backup jobs (forwarding is TODO).
- Added CORS headers helper.

### ✅ How to Test
1. Send a POST request to `/api/backup` with `chatId` and `userId`.
2. Confirm a backup ID is returned and job is queued.

### 🔥 Notes
- Forwarding logic for backup processing still needs to be implemented.