### PR TITLE
feat: show latest backup time

### DIFF
--- a/app/components/dashboard/backed-chats.tsx
+++ b/app/components/dashboard/backed-chats.tsx
@@ -2,33 +2,83 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Button } from '../ui/button'
 import { Upload, ShieldCheck } from 'lucide-react'
 import { useBackups } from '@/providers/backup'
+import { useTelegram } from '@/providers/telegram'
+import { MouseEventHandler, useEffect, useState } from 'react'
+import { Dialog } from '@/vendor/telegram/tl/custom/dialog'
+import { Backup } from '@/api'
+import { decodeStrippedThumb, toJPGDataURL } from '@/lib/utils'
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-function ChatItem() {
+interface DialogItemProps {
+	dialog: Dialog
+	onClick: MouseEventHandler
+	latestBackup?: Backup
+}
+
+const DialogItem = ({ dialog, onClick, latestBackup }: DialogItemProps) => {
+	const title = (dialog.name ?? dialog.title ?? '').trim() || 'Unknown'
+	const parts = title.replace(/[^a-zA-Z ]/ig, '').trim().split(' ')
+	const initials = parts.length === 1 ? title[0] : (parts[0][0] + parts[parts.length - 1][0]).toUpperCase()
+
+	let thumbSrc = ''
+	// @ts-expect-error Telegram types are messed up
+	const strippedThumbBytes = dialog.entity?.photo?.strippedThumb
+	if (strippedThumbBytes) {
+		thumbSrc = toJPGDataURL(decodeStrippedThumb(strippedThumbBytes))
+	}
+
+	let latestBackupDate
+	if (latestBackup) {
+		latestBackupDate = new Date(latestBackup.period[1] * 1000)
+	}
+
 	return (
-		<div className="flex justify-between active:bg-accent px-5 py-3">
+		<div className="flex justify-start gap-10 items-center active:bg-accent px-5 py-3" data-id={String(dialog.id)} onClick={onClick}>
 			<div className="flex gap-4 items-center">
 				<Avatar>
-					<AvatarImage src="https://github.com/shadcn.png" />
-					<AvatarFallback>CN</AvatarFallback>
+					<AvatarImage src={thumbSrc} />
+					<AvatarFallback>{initials}</AvatarFallback>
 				</Avatar>
 				<div>
-					<h1 className="font-semibold text-foreground/80">Shadcn</h1>
-					<p className="text-sm text-foreground/60">Theresa Webbs</p>
+					<h1 className="font-semibold text-foreground/80">{title}</h1>
+					<p className="text-sm text-foreground/60">Last Backup: {latestBackupDate ? latestBackupDate.toLocaleString() : <span className="text-red-900">Never</span>}</p>
 				</div>
 			</div>
-			<Button className="rounded-full h-10 w-10" variant="outline">
-				<Upload className="text-primary" />
-			</Button>
 		</div>
 	)
 }
 
 export default function BackedChats() {
+	const [{ client }] = useTelegram()
 	const [{ backups }] = useBackups()
+	const [dialogs, setDialogs] = useState<Dialog[]>([])
+	const [loading, setLoading] = useState(true)
+
+	const sortedBackups = backups.items.sort((a, b) => b.period[1] - a.period[1])
+
+	useEffect(() => {
+		let cancel = false
+		const dialogs = []
+		;(async () => {
+			if (!client.connected) await client.connect()
+			for await (const dialog of client.iterDialogs()) {
+				if (cancel) return
+				if (loading) setLoading(false)
+				dialogs.push(dialog)
+				setDialogs([...dialogs])
+			}
+		})()
+		return () => { cancel = true }
+	}, [client])
+
+	const handleDialogItemClick: MouseEventHandler = e => {
+		const id = BigInt(e.currentTarget.getAttribute('data-id') ?? 0)
+		console.log('TODO: display backup', id)
+		// TODO: display backup
+	}
+
 	return (
 		<div className="flex flex-col gap-5">
-			<h1 className="px-5">Backed up Chats</h1>
+			<h1 className="px-5">Chats</h1>
 			{backups.items.length === 0 && (
 				<div className="flex flex-col justify-center items-center px-10 pt-20 gap-2">
 					<div className="text-foreground/40 p-2">
@@ -39,13 +89,10 @@ export default function BackedChats() {
 				</div>
 			)}
 			<div className="flex flex-col">
-				{backups.items.sort((a, b) => b.created - a.created).map((b) => (
-					<div key={b.data.toString()} className="text-xs">
-						ID: <span>{b.data.toString()}</span><br/>
-						{new Date(b.created).toISOString()}
-					</div>
-					// <ChatItem key={chat.id} />
-				))}
+				{dialogs.map(d => {
+					const latestBackup = sortedBackups.find(b => d.id && b.dialogs.has(d.id.value))
+					return <DialogItem key={String(d.id)} dialog={d} latestBackup={latestBackup} onClick={handleDialogItemClick} />
+				})}
 			</div>
 		</div>
 	)

--- a/app/components/dashboard/index.tsx
+++ b/app/components/dashboard/index.tsx
@@ -11,11 +11,11 @@ export default function Dashboard() {
 
 	return (
 		<div className="w-full flex items-center flex-col h-full">
-			<div className="w-full px-5">
+			{/* <div className="w-full px-5">
 				<Head />
-			</div>
+			</div> */}
 			{jobs.items.map(j => <JobItem key={j.id} job={j} />)}
-			<div className="rounded-t-xl bg-background flex-grow w-full shadow-t-xl mt-5 pt-5">
+			<div className="rounded-t-xl bg-background flex-grow w-full shadow-t-xl pt-5">
 				<BackedChats />
 			</div>
 			<div className="sticky bottom-0 bg-white w-full px-5 pb-5">
@@ -29,8 +29,8 @@ export default function Dashboard() {
 
 const JobItem = ({ job }: { job: Job }) => {
 	return (
-		<div className="w-full px-5">
-			<div className="w-full mt-5 bg-background rounded-sm border">
+		<div className="w-full px-5 mb-5">
+			<div className="w-full bg-background rounded-sm border">
 				<p className="px-5 pt-3">Backup <span className="capitalize">{job.state}</span></p>
 				<div className="flex justify-between items-center px-3 py-3">
 					<div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">

--- a/app/components/layouts/menu.tsx
+++ b/app/components/layouts/menu.tsx
@@ -49,7 +49,7 @@ export function Menu() {
 					</div>
 				</DrawerTitle>
 
-				<div className="bg-background">
+				{/* <div className="bg-background">
 					<div className="py-5 px-5 flex flex-col gap-2 border-b border-foreground/10">
 						<p className="text-base text-foreground/80">Storage</p>
 						<Progress value={55} className="w-full" />
@@ -66,7 +66,7 @@ export function Menu() {
 							<Button className="w-full">Go Pro</Button>
 						</div>
 					</div>
-				</div>
+				</div> */}
 			</DrawerContent>
 		</Drawer>
 	)

--- a/app/lib/backup/manager.ts
+++ b/app/lib/backup/manager.ts
@@ -49,6 +49,13 @@ class JobManager {
 
         let dialogsCompleted = 0
         const data = await Runner.run(this, space, dialogs, absPeriod, {
+          onDialogRetrieved: async () => {
+            try {
+              await this.#jobs.update(id, { progress: ((dialogsCompleted * 2) + 1) / (dialogs.size * 2) })
+            } catch (err) {
+              console.error(err)
+            }
+          },
           onDialogStored: async () => {
             console.log('dialog was stored!')
             dialogsCompleted++
@@ -85,6 +92,13 @@ class JobManager {
 
         let dialogsCompleted = 0
         const data = await Runner.run(this, job.space, job.dialogs, job.period, {
+          onDialogRetrieved: async () => {
+            try {
+              await this.#jobs.update(id, { progress: ((dialogsCompleted * 2) + 1) / (job.dialogs.size * 2) })
+            } catch (err) {
+              console.error(err)
+            }
+          },
           onDialogStored: async () => {
             console.log('dialog was stored!')
             dialogsCompleted++

--- a/app/lib/store/cloudstorage-backups.ts
+++ b/app/lib/store/cloudstorage-backups.ts
@@ -44,7 +44,7 @@ export const add = async (target: EventTarget, backup: Backup) => {
   }))
   const str = await cloudStorage.getItem('backups') || '[]'
   const ids: Link[] = dagJSON.parse(str)
-  await cloudStorage.setItem('backups', dagJSON.stringify([...ids, backup.data]))
+  await cloudStorage.setItem('backups', dagJSON.stringify([backup.data, ...ids]))
   target.dispatchEvent(new CustomEvent('add', { detail: backup }))
 }
 

--- a/app/lib/store/localstorage-jobs.ts
+++ b/app/lib/store/localstorage-jobs.ts
@@ -48,7 +48,7 @@ export const add = (target: EventTarget, job: Job) => {
     dialogs: [...job.dialogs].map(id => id.toString())
   }))
   const jobIDs: string[] = dagJSON.parse(localStorage.getItem('jobs') ?? '[]')
-  localStorage.setItem('jobs', dagJSON.stringify([...jobIDs, job.id]))
+  localStorage.setItem('jobs', dagJSON.stringify([job.id, ...jobIDs]))
   target.dispatchEvent(new CustomEvent('add', { detail: job }))
 }
 


### PR DESCRIPTION
* Display datetime of latest backup next to chat in both the dashboard and chat selection for backup 
* Display "Never" in danger red

<img width="442" alt="Screenshot 2025-04-15 at 13 04 03" src="https://github.com/user-attachments/assets/59007635-0280-4f32-9e1d-bdf68c3b88ae" />

Also some general tweaks:

* Temporarily hide the points/leaderboard section on the dashboard
* Temporarily hide the storage usage progress bar in the menu
* Store list of backups/jobs with most recent first (this should make sorting them faster)
* Add a progress callback `onDialogRetrieved` when we downloaded all the messages but did not encrypt/store them yet - more progress events = more user feedback that something is happening