### PR TITLE
feat: add message types

### DIFF
--- a/app/api.ts
+++ b/app/api.ts
@@ -95,7 +95,7 @@ export interface DialogData extends EntityData {
    *
    * Each list has a maximum of 1,000 messages.
    */
-  messages: Array<Link<EncryptedByteView<Array<MessageData>>>>
+  messages: Array<Link<EncryptedByteView<Array<MessageData|ServiceMessageData>>>>
 }
 
 export type EntityRecordData = Record<ToString<EntityID>, EntityData>
@@ -115,11 +115,9 @@ export interface EntityData {
   }
 }
 
-export type MessageType = 'message' | 'service'
-
-export interface MessageData {
+export type MessageData =  {
   id: MessageID
-  type: MessageType
+  type: 'message'
   /**
    * ID of the peer who sent this message. It will be undefined for anonymous
    * messages.
@@ -129,4 +127,16 @@ export interface MessageData {
   date: number
   /** The string text of the message. */
   message: string
+}
+
+export interface ServiceMessageData {
+  id: MessageID
+  type: 'service'
+  /**
+   * ID of the peer who sent this message. It will be undefined for anonymous
+   * messages.
+   */
+  from?: ToString<EntityID>
+  /** Timestamp in seconds since Unix epoch that this message was sent. */
+  date: number
 }

--- a/app/api.ts
+++ b/app/api.ts
@@ -115,7 +115,7 @@ export interface EntityData {
   }
 }
 
-export type MessageData =  {
+export interface MessageData {
   id: MessageID
   type: 'message'
   /**

--- a/app/api.ts
+++ b/app/api.ts
@@ -95,7 +95,7 @@ export interface DialogData extends EntityData {
    *
    * Each list has a maximum of 1,000 messages.
    */
-  messages: Array<Link<EncryptedByteView<MessageData[]>>>
+  messages: Array<Link<EncryptedByteView<Array<MessageData>>>>
 }
 
 export type EntityRecordData = Record<ToString<EntityID>, EntityData>
@@ -115,10 +115,16 @@ export interface EntityData {
   }
 }
 
+export type MessageType = 'message' | 'service'
+
 export interface MessageData {
   id: MessageID
-  /** ID of the peer who sent this message. */
-  from: ToString<EntityID>
+  type: MessageType
+  /**
+   * ID of the peer who sent this message. It will be undefined for anonymous
+   * messages.
+   */
+  from?: ToString<EntityID>
   /** Timestamp in seconds since Unix epoch that this message was sent. */
   date: number
   /** The string text of the message. */

--- a/app/lib/backup/runner.ts
+++ b/app/lib/backup/runner.ts
@@ -1,4 +1,4 @@
-import { AbsolutePeriod, BackupData, BackupModel, DialogData, EncryptedByteView, EntityData, EntityRecordData, EntityType, MessageData } from '@/api'
+import { AbsolutePeriod, BackupData, BackupModel, DialogData, EncryptedByteView, EntityData, EntityRecordData, EntityType, MessageData, ServiceMessageData } from '@/api'
 import { Link, SpaceDID, Client as StorachaClient, UnknownLink } from '@storacha/ui-react'
 import { Api, TelegramClient } from '@/vendor/telegram'
 import * as dagCBOR from '@ipld/dag-cbor'
@@ -36,12 +36,12 @@ export const run = async (ctx: Context, space: SpaceDID, dialogs: Set<bigint>, p
   let dialogEntity: Entity | null = null
 
   let entities: EntityRecordData = {}
-  let messages: MessageData[] = []
-  let messageLinks: Array<Link<EncryptedByteView<MessageData[]>>> = []
+  let messages: Array<MessageData | ServiceMessageData> = []
+  let messageLinks: Array<Link<EncryptedByteView<Array<MessageData | ServiceMessageData>>>> = []
 
   // null value signals that no more messages will come and the current dialog
   // can now be finalized
-  let messageIterator: AsyncIterator<Api.Message> | null = null
+  let messageIterator: AsyncIterator<Api.TypeMessage> | null = null
 
   const blockStream = new ReadableStream<Block>({
     async pull (controller) {
@@ -118,6 +118,10 @@ export const run = async (ctx: Context, space: SpaceDID, dialogs: Set<bigint>, p
           break
         }
 
+        if (message.className === 'MessageEmpty') {
+          // TODO: IDK what do we do here?
+          continue
+        }
         let fromID
         if (message.fromId?.className === 'PeerUser') {
           fromID = message.fromId.userId
@@ -204,9 +208,8 @@ const encodeAndEncrypt = <T>(ctx: Context, data: T) =>
 //     }
 // }
 
-const toMessageData = (message: Api.Message): MessageData => {
-  const id = message.id
-  let from = '0'
+const toMessageData = (message: Api.Message | Api.MessageService): MessageData | ServiceMessageData => {
+  let from
   if (message.fromId?.className === 'PeerUser') {
     from = message.fromId.userId.toString()
   } else if (message.fromId?.className === 'PeerChat') {
@@ -214,8 +217,23 @@ const toMessageData = (message: Api.Message): MessageData => {
   } else if (message.fromId?.className === 'PeerChannel') {
     from = message.fromId.channelId.toString()
   }
-  const date = message.date ?? 0
-  return { id, from, date, message: message.message ?? '' }
+
+  if (message.className === 'MessageService') {
+    return {
+      id: message.id,
+      type: 'service',
+      ...(from == null ? {} : { from }),
+      date: message.date,
+    }
+  }
+
+  return {
+    id: message.id,
+    type: 'message',
+    ...(from == null ? {} : { from }),
+    date: message.date,
+    message: message.message ?? ''
+  }
 }
 
 const toEntityData = (entity: Entity): EntityData => {


### PR DESCRIPTION
Add message `type` field and definitions for both types: regular and "service".

Necessary follow on for service messages: https://github.com/storacha/tg-miniapp/issues/40

Follow on for regular messages: https://github.com/storacha/tg-miniapp/issues/41