### PR TITLE
refactor: improve loading visualization

### DIFF
--- a/app/api.ts
+++ b/app/api.ts
@@ -121,10 +121,20 @@ export interface MessageData {
   id: MessageID
   type: 'message'
   /**
-   * ID of the peer who sent this message. It will be undefined for anonymous
-   * messages.
+   * ID of the peer who sent this message. Will be undefined for anonymous messages.
+   * Indicates the sender of the message.
+   *
+   * In a private chat, this is usually undefined since the context already implies the sender.
    */
   from?: ToString<EntityID>
+
+  /**
+   * ID of the peer (chat, user, or channel) where the message was sent.
+   * Indicates the destination or context of the message.
+   *
+   * In a private chat, this will be the ID of the other user you're chatting with.
+   */
+  peer: ToString<EntityID>
   /** Timestamp in seconds since Unix epoch that this message was sent. */
   date: number
   /** The string text of the message. */
@@ -1158,4 +1168,11 @@ export interface StarGiftActionData {
 
 export interface UnknownActionData {
    type: 'unknown'
+}
+
+export interface RestoredBackup {
+  dialogData: DialogData
+  messages: MessageData[]
+  participants: Record<string, EntityData>
+  hasMoreMessages: boolean
 }

--- a/app/app/dialog/[id]/page.tsx
+++ b/app/app/dialog/[id]/page.tsx
@@ -1,18 +1,16 @@
 'use client'
 
-import * as dagCBOR from '@ipld/dag-cbor'
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 import { useTelegram } from '@/providers/telegram'
-import { cloudStorage} from '@telegram-apps/sdk-react'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 
-import * as Crypto from '@/lib/crypto'
 import { Media } from '@/components/ui/media'
 import { Layouts } from '@/components/layouts'
 import { decodeStrippedThumb, toJPGDataURL } from '@/lib/utils'
-import { BackupModel, DialogData, EntityData, MessageData, ServiceMessageData } from '@/api'
+import { DialogData, EntityData, MessageData, ServiceMessageData } from '@/api'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { ConnectError } from '@/components/backup/connect'
+import { useBackups } from '@/providers/backup'
 
 export const runtime = 'edge'
 
@@ -21,6 +19,7 @@ type BackupDialogProps = {
   dialog: DialogData
   messages: (MessageData | ServiceMessageData)[]
   participants: Record<string, EntityData>
+  onScrollTop: () => void 
 }
 
 const formatDate = (timestamp: number) => (new Date(timestamp * 1000)).toLocaleString()
@@ -38,13 +37,33 @@ function BackupDialog({
   dialog,
   messages,
   participants,
+  onScrollTop,
 }: BackupDialogProps) {
+  const chatContainerRef = useRef<HTMLDivElement>(null)
   const sortedMessages = [...messages].sort((a, b) => a.date - b.date)
   
   let dialogThumbSrc = ''
   if(dialog.photo?.strippedThumb){
     dialogThumbSrc = toJPGDataURL(decodeStrippedThumb(dialog.photo?.strippedThumb))
   }
+
+  useEffect(() => {
+    const handleScroll = () => {
+      if (chatContainerRef.current) {
+        const { scrollTop } = chatContainerRef.current
+        if (scrollTop === 0) {
+          onScrollTop()
+        }
+      }
+    }
+
+    const chatContainer = chatContainerRef.current
+    chatContainer?.addEventListener('scroll', handleScroll)
+
+    return () => {
+      chatContainer?.removeEventListener('scroll', handleScroll)
+    }
+  }, [onScrollTop])
   
   return (
     <div className="flex flex-col h-screen bg-background">
@@ -61,7 +80,7 @@ function BackupDialog({
       </div>
 
       {/* Messages */}
-      <div className="flex-1 overflow-y-auto px-4 py-6 space-y-4">
+      <div ref={chatContainerRef} className="flex-1 overflow-y-auto px-4 py-6 space-y-4">
         {sortedMessages
           .filter((msg) => msg.type !== "service") // TODO: handle this once the message service types are defined
           .map((msg, index) => {
@@ -122,111 +141,62 @@ function BackupDialog({
   )
 }
 
-const getFromStoracha = async (cid: string) => {
-  const url = new URL(`/ipfs/${cid}`, process.env.NEXT_PUBLIC_STORACHA_GATEWAY_URL)
-  const response = await fetch(url)
-  if (!response.ok) {
-    throw new Error(`Failed to fetch: ${response.status} ${response.statusText} ${url}`);
-  }
-  return response
-}
 
 export default function Page () {
-  const [{ client }] = useTelegram()
-  const [loading, setLoading] = useState(true)
-  const [dialogData, setDialogData] = useState<DialogData | null>(null)
-  const [messages, setMessages] = useState<MessageData[]>([])
-  const [userId, setUserId] = useState<string>()
-  const [participants, setParticipants] = useState<Record<string, EntityData>>({})
   const router = useRouter()
-  const [restoreErr, setRestoreErr] = useState<Error>()
+  const [{ client }] = useTelegram()
+  const [{ restoredBackup }, { restoreBackup, fetchMoreMessages }] = useBackups()
   const params = useParams<{ id: string }>()
   const searchParams = useSearchParams()
   const backupCid = searchParams.get('backupData')
-
+  const [userId, setUserId] = useState<string>()
+  
   useEffect(() => {
-      const restoreBackup = async () => {
-        try{
-          if (!client.connected) await client.connect()
-
-          const userId = (await client.getMe()).id
-          setUserId(userId.toString())
-
-          if(!cloudStorage.getKeys.isAvailable()){
-            throw new Error('Error trying to access cloud storage')
-          }
+    const fetchBackup = async () => {
+      try {
+        if (!client.connected) await client.connect()
           
-          const encryptionPassword = await cloudStorage.getItem('encryption-password')
-          if (!encryptionPassword) {
-            throw new Error('Encryption password not found in cloud storage')
-          }
-          
-          const response = await getFromStoracha(`${backupCid}?format=raw`)
-          const backupRaw = dagCBOR.decode(new Uint8Array(await response.arrayBuffer())) as BackupModel
+        const userId = (await client.getMe()).id.toString()
+        setUserId(userId)
 
-          const dialogCid = backupRaw['tg-miniapp-backup@0.0.1'].dialogs[params.id].toString()
-          const dialogResult = await getFromStoracha(dialogCid)
-          const encryptedDialogData = new Uint8Array(await dialogResult.arrayBuffer())
-
-          const decryptedDialogData = dagCBOR.decode(
-            await Crypto.decryptContent(encryptedDialogData, encryptionPassword)
-          ) as DialogData
-          
-          // Restore messages and entities
-          const [restoredMessages, restoredEntities] = await Promise.all([
-            // Fetch and decrypt messages
-            (async () => {
-              const messages: MessageData[] = []
-              for (const messageLink of decryptedDialogData.messages) {
-                const messagesResult = await getFromStoracha(messageLink.toString())
-                const encryptedMessageData = new Uint8Array(await messagesResult.arrayBuffer())
-                const decryptedMessageData = dagCBOR.decode(
-                  await Crypto.decryptContent(encryptedMessageData, encryptionPassword)
-                ) as MessageData[]
-                messages.push(...decryptedMessageData)
-              }
-              return messages
-            })(),
-      
-            // Fetch and decrypt entities
-            (async () => {
-              const entitiesResult = await getFromStoracha(decryptedDialogData.entities.toString())
-              const encryptedEntitiesData = new Uint8Array(await entitiesResult.arrayBuffer())
-              return dagCBOR.decode(
-                await Crypto.decryptContent(encryptedEntitiesData, encryptionPassword)
-              ) as Record<string, EntityData>
-            })(),
-          ])
-    
-          // console.log(JSON.stringify(restoredMessages))
-          // console.log(JSON.stringify(restoredEntities))
-
-          setLoading(false)
-          setDialogData(decryptedDialogData)
-          setMessages(restoredMessages)
-          setParticipants(restoredEntities)
-
-        } catch (error) {
-          console.error('Error in useEffect:', error)
-            setRestoreErr(new Error(`restoring backup failed! Reason: ${error instanceof Error ? error.message : 'Unknown error'}`))
-        }
+        await restoreBackup(backupCid!, params.id, 50)
+      } catch (error) {
+        console.error('Error in useEffect:', error)
+        
       }
-      restoreBackup()
-     
-    }, [client, backupCid, params.id])
+    }
+
+    fetchBackup()
+  }, [client, backupCid, params.id, restoreBackup])
+
+  const handleFetchMoreMessages = async () => {
+    return fetchMoreMessages(restoredBackup.item?.messages.length || 0, 50)
+  }
 
   return (
     <Layouts isSinglePage isBackgroundBlue>
-      {restoreErr && <ConnectError open={restoreErr != undefined} error={restoreErr} onDismiss={() => { setRestoreErr(undefined); router.back()}} />}
-      {loading && <p className='text-center'>Loading...</p> }
-      {!loading && !dialogData && 
+       {restoredBackup.error && (
+        <ConnectError
+          open={!!restoredBackup.error}
+          error={restoredBackup.error}
+          onDismiss={() => router.back()}
+        />
+      )}
+      {restoredBackup.loading && <p className="text-center">Loading...</p>}
+      {!restoredBackup.loading && !restoredBackup.item && (
         <div className="flex flex-col items-center justify-center h-screen">
           <p className="text-lg font-semibold text-red-500">Dialog not found</p>
         </div>
-      }
-      {userId && dialogData && 
-        <BackupDialog userId={userId} dialog={dialogData} messages={messages} participants={participants} />
-      }
+      )}
+      {userId && restoredBackup.item && (
+        <BackupDialog
+          userId={userId}
+          dialog={restoredBackup.item.dialogData}
+          messages={restoredBackup.item.messages}
+          participants={restoredBackup.item.participants}
+          onScrollTop={handleFetchMoreMessages}
+        />
+      )}
     </Layouts>
   )
 }

--- a/app/components/dashboard/backed-chats.tsx
+++ b/app/components/dashboard/backed-chats.tsx
@@ -52,7 +52,7 @@ const DialogItem = ({ dialog, onClick, latestBackup }: DialogItemProps) => {
 
 export default function BackedChats() {
 	const [{ client }] = useTelegram()
-	const [{ backups }, {setDialog}] = useBackups()
+	const [{ backups }] = useBackups()
 	const router = useRouter()
 	const [dialogs, setDialogs] = useState<Dialog[]>([])
 	const [loading, setLoading] = useState(true)
@@ -80,7 +80,6 @@ export default function BackedChats() {
 		const backupWithDialog = sortedBackups.find(b => id && b.dialogs.has(id))
 		const dialog = dialogs.find(d => d.id.toString() == id.toString())
 		if (!backupWithDialog || !dialog) return
-		setDialog(dialog)
 		const backupData = backupWithDialog.data.toString()
 		const pageId = dialog.entity ? dialog.entity.id : id
 		router.push(`/dialog/${pageId}?backupData=${encodeURIComponent(backupData)}`)

--- a/app/lib/backup/recoverer.ts
+++ b/app/lib/backup/recoverer.ts
@@ -1,0 +1,82 @@
+import * as dagCBOR from '@ipld/dag-cbor'
+import * as Crypto from '@/lib/crypto'
+import { BackupModel, DialogData, EntityData, MessageData, RestoredBackup } from '@/api'
+
+export const getFromStoracha = async (cid: string) => {
+	const url = new URL(`/ipfs/${cid}`, process.env.NEXT_PUBLIC_STORACHA_GATEWAY_URL)
+	const response = await fetch(url)
+	if (!response.ok) {
+		throw new Error(`Failed to fetch: ${response.status} ${response.statusText} ${url}`);
+	}
+	return response
+}
+
+export const dercyptAndDecode = async (encryptedData: Uint8Array, encryptionPassword: string ) => {
+	return dagCBOR.decode(
+        await Crypto.decryptContent(encryptedData, encryptionPassword)
+    )
+}
+
+export const restoreBackup = async (
+  backupCid: string,
+  dialogId: string,
+  encryptionPassword: string,
+  limit: number = 50
+): Promise<RestoredBackup> => {
+  const response = await getFromStoracha(`${backupCid}?format=raw`)
+  const backupRaw = dagCBOR.decode(new Uint8Array(await response.arrayBuffer())) as BackupModel
+
+  const dialogCid = backupRaw['tg-miniapp-backup@0.0.1'].dialogs[dialogId].toString()
+  const dialogResult = await getFromStoracha(dialogCid)
+  const encryptedDialogData = new Uint8Array(await dialogResult.arrayBuffer())
+
+  const decryptedDialogData = dagCBOR.decode(
+    await Crypto.decryptContent(encryptedDialogData, encryptionPassword)
+  ) as DialogData
+
+  const messagesToFetch = decryptedDialogData.messages.slice(0, limit)
+  const hasMoreMessages = decryptedDialogData.messages.length > limit
+
+  const [restoredMessages, restoredEntities] = await Promise.all([
+    // Fetch and decrypt messages
+    (async () => {
+      const messages: MessageData[] = []
+      for (const messageLink of messagesToFetch) {
+        const messagesResult = await getFromStoracha(messageLink.toString())
+        const encryptedMessageData = new Uint8Array(await messagesResult.arrayBuffer())
+        const decryptedMessageData = await dercyptAndDecode(encryptedMessageData, encryptionPassword) as MessageData[]
+        messages.push(...decryptedMessageData)
+      }
+      return messages
+    })(),
+
+    // Fetch and decrypt entities
+    (async () => {
+      const entitiesResult = await getFromStoracha(decryptedDialogData.entities.toString())
+      const encryptedEntitiesData = new Uint8Array(await entitiesResult.arrayBuffer())
+      return await dercyptAndDecode(encryptedEntitiesData, encryptionPassword) as Record<string, EntityData>
+    })(),
+  ])
+
+  return {
+    dialogData: decryptedDialogData,
+    messages: restoredMessages,
+    participants: restoredEntities,
+    hasMoreMessages
+  }
+}
+
+
+export const fetchMoreMessages = async (dialogData: DialogData,  encryptionPassword: string, offset: number, limit: number) => {
+    const newMessages: MessageData[] = []
+    const messagesToFetch = dialogData.messages.slice(offset, offset + limit)
+    
+    for (const messageLink of messagesToFetch) {
+      const messagesResult = await getFromStoracha(messageLink.toString())
+      const encryptedMessageData = new Uint8Array(await messagesResult.arrayBuffer())
+      const decryptedMessageData = await dercyptAndDecode(encryptedMessageData, encryptionPassword) as MessageData[]
+      newMessages.push(...decryptedMessageData)
+    }
+    
+    return newMessages
+}

--- a/app/package.json
+++ b/app/package.json
@@ -30,7 +30,6 @@
 		"@storacha/ui-react": "^2.6.4",
 		"@storacha/upload-client": "^1.0.9",
 		"@telegram-apps/sdk-react": "^2.0.20",
-		"@ucanto/core": "^10.3.1",
 		"carstream": "^2.3.0",
 		"class-variance-authority": "^0.7.1",
 		"clsx": "^2.1.1",


### PR DESCRIPTION
This PR includes some improvements requested in #53 

- Adds lazy loading for messages, so we no longer buffer the entire chat history in memory.  
- Adds `peer` field to `MessageData`.  
- Cleans up unused `dialog` and `setDialog` from the Backup provider.  
- Moves `restoreBackup` logic from the page to the Backup provider.