### PR TITLE
chore: improve fetch dialogs logic to load more on scroll

### DIFF
--- a/app/components/backup/chats.tsx
+++ b/app/components/backup/chats.tsx
@@ -1,4 +1,4 @@
-import { ChangeEventHandler, FormEventHandler, MouseEventHandler, useState } from 'react'
+import { ChangeEventHandler, FormEventHandler, MouseEventHandler, useEffect, useRef, useState } from 'react'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { Checkbox } from '@/components/ui/checkbox'
 import { Input } from '@/components/ui/input'
@@ -55,7 +55,7 @@ export interface ChatsProps {
 export default function Chats({ selections, onSelectionsChange, onSubmit }: ChatsProps) {
 	const [{ backups }] = useBackups()
 	const [searchTerm, setSearchTerm] = useState('')
-	const [{ dialogs, loadingDialogs, error }] = useTelegram()
+	const [{ dialogs, loadingDialogs, error }, { loadMoreDialogs }] = useTelegram()
 
 	const [typeFilter, setTypeFilter] = useState<Filter>(() => noFilter)
 	const [searchFilter, setSearchFilter] = useState<Filter>(() => noFilter)
@@ -63,6 +63,26 @@ export default function Chats({ selections, onSelectionsChange, onSubmit }: Chat
 	const items = dialogs.filter(and(typeFilter, searchFilter))
 
 	const sortedBackups = backups.items.sort((a, b) => b.params.period[1] - a.params.period[1])
+	const observerRef = useRef<HTMLDivElement | null>(null)
+
+	useEffect(() => {
+		if (!observerRef.current) return
+
+		const observer = new IntersectionObserver(
+			entries => {
+				if (entries[0].isIntersecting && !loadingDialogs) {
+					loadMoreDialogs()
+				}
+			},
+			{
+				threshold: 0.1,
+			}
+		)
+
+		observer.observe(observerRef.current)
+		return () => observer.disconnect()
+	}, [loadMoreDialogs, loadingDialogs])
+	
 
 	const handleSearchChange: ChangeEventHandler<HTMLInputElement> = e => {
 		setSearchTerm(e.target.value)
@@ -122,6 +142,7 @@ export default function Chats({ selections, onSelectionsChange, onSubmit }: Chat
 								return <DialogItem key={d.id} dialog={d} selected={selections.has(BigInt(d.id || 0))} onClick={handleDialogItemClick} latestBackup={latestBackup} />
 							})}
 							{loadingDialogs && <p className='text-center'>Loading chats...</p>}
+							<div ref={observerRef} className="h-10" />
 							{!loadingDialogs && !items.length && <p className='text-center'>No chats found!</p>}
 						</>
 					)}

--- a/app/components/dashboard/backed-chats.tsx
+++ b/app/components/dashboard/backed-chats.tsx
@@ -2,7 +2,7 @@ import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { ShieldCheck, ChevronRight } from 'lucide-react'
 import { useBackups } from '@/providers/backup'
 import { useTelegram } from '@/providers/telegram'
-import { MouseEventHandler } from 'react'
+import { MouseEventHandler, useEffect, useRef } from 'react'
 import { Backup, DialogInfo } from '@/api'
 import { useRouter } from 'next/navigation'
 interface DialogItemProps {
@@ -46,9 +46,28 @@ const DialogItem = ({ dialog, onClick, latestBackup }: DialogItemProps) => {
 export default function BackedChats() {
 	const router = useRouter()
 	const [{ backups }] = useBackups()
-	const [{ dialogs, loadingDialogs, error}] = useTelegram()
+	const [{ dialogs, loadingDialogs, error }, { loadMoreDialogs }] = useTelegram()
 
 	const sortedBackups = backups.items.sort((a, b) => b.params.period[1] - a.params.period[1])
+	const observerRef = useRef<HTMLDivElement | null>(null)
+
+	useEffect(() => {
+		if (!observerRef.current) return
+
+		const observer = new IntersectionObserver(
+			entries => {
+				if (entries[0].isIntersecting && !loadingDialogs) {
+					loadMoreDialogs()
+				}
+			},
+			{
+				threshold: 0.1,
+			}
+		)
+
+		observer.observe(observerRef.current)
+		return () => observer.disconnect()
+	}, [loadMoreDialogs, loadingDialogs])
 
 	const handleDialogItemClick: MouseEventHandler = e => {
 		e.preventDefault()
@@ -75,12 +94,13 @@ export default function BackedChats() {
 						</div>
 					)}
 					{backups.items.length > 0 && (
-						<div   className="flex flex-col">
-							{loadingDialogs && <p className='text-center'>Loading chats...</p>}
-							{!loadingDialogs && dialogs.map(d => {
+						<div  className="flex flex-col">
+							{dialogs.map(d => {
 								const latestBackup = sortedBackups.find(b => d.id && b.params.dialogs.includes(d.id))
 								return <DialogItem key={String(d.id)} dialog={d} latestBackup={latestBackup} onClick={handleDialogItemClick} />
 							})}
+							<div ref={observerRef} className="h-10" />
+							{loadingDialogs && <p className='text-center'>Loading chats...</p>}
 						</div>
 					)}
 				</>

--- a/app/providers/telegram.tsx
+++ b/app/providers/telegram.tsx
@@ -14,6 +14,7 @@ export interface ContextState {
 
 export interface ContextActions {
   getMe: () => Promise<string>
+  loadMoreDialogs: () => Promise<void>
 }
 
 export type ContextValue = [state: ContextState, actions: ContextActions]
@@ -28,6 +29,7 @@ export const ContextDefaultValue: ContextValue = [
   },
   {
     getMe: () => Promise.reject(new Error('provider not setup')),
+    loadMoreDialogs: () => Promise.reject(new Error('provider not setup')),
   },
 ]
 
@@ -42,49 +44,45 @@ export const Provider = ({ children }: PropsWithChildren): ReactNode => {
   const user = useSignal(initData.user)
   const launchParams = useLaunchParams()
   const [dialogs, setDialogs] = useState<DialogInfo[]>([])
-  const [offsetParams, setOffsetParams] = useState<{limit: number, offsetId?: number, offsetDate?: number, offsetPeer?: string}>({ limit: 10 })
+  const [offsetParams, setOffsetParams] = useState<{limit: number, offsetId?: number, offsetDate?: number, offsetPeer?: string}>({ limit: 20 })
 	const [hasMore, setHasMore] = useState(true)
   const [loadingDialogs, setLoadingDialogs] = useState(false)
   const [error, setError] = useState<Error | null>(null)
 
-  useEffect(() => {
-		if (!tgSessionString || !hasMore) return
-
-		let cancel = false;
-		
-		(async () => {
-			try {
-        setError(null)
-				setLoadingDialogs(true)
-        
-				const { chats, offsetParams: newOffsetParams } = await listDialogs(offsetParams)
-				if (cancel) return
-
-				setDialogs([...dialogs, ...chats])
-				setOffsetParams({...newOffsetParams, limit: 100})
-				setHasMore(chats.length > 0)
-			} catch (err: any) {
-				console.error('Failed to fetch dialogs:', err)
-        setError(new Error('Failed to load dialogs. Please try again.', {cause: err}))
-			} finally {
-				if (!cancel) setLoadingDialogs(false)
-			}
-		})()
-
-		return () => {
-			cancel = true
-		}
-	}, [tgSessionString, offsetParams])
-
-
   const listDialogs = useCallback(
-      async (paginationParams = { limit: 10 }) => {
-        if (!tgSessionString) return { chats: [], offsetParams: {} }
-        return listDialogsRequest(tgSessionString, paginationParams )
-      },
-      [tgSessionString]
+    async (paginationParams = { limit: 10 }) => {
+      if (!tgSessionString) return { chats: [], offsetParams: {} }
+      return listDialogsRequest(tgSessionString, paginationParams )
+    },
+    [tgSessionString]
   )
-  
+
+  const loadMoreDialogs = useCallback(async () => {
+    if (!tgSessionString || !hasMore || loadingDialogs) return
+
+    setError(null)
+    setLoadingDialogs(true)
+    try {
+      const { chats, offsetParams: newOffsetParams } = await listDialogs(offsetParams)
+      setDialogs([...dialogs, ...chats])
+      setOffsetParams({ ...newOffsetParams, limit: 100 })
+      setHasMore(chats.length > 0)
+    } catch (err: any) {
+      console.error('Failed to fetch dialogs:', err)
+      setError(new Error('Failed to load dialogs. Please try again.', { cause: err }))
+    } finally {
+      setLoadingDialogs(false)
+    }
+  }, [tgSessionString, hasMore, loadingDialogs, offsetParams, listDialogs])
+
+  useEffect(() => {
+		if (!tgSessionString) return
+    setDialogs([])
+    setOffsetParams({ limit: 20 })
+    setHasMore(true)
+    loadMoreDialogs()
+	}, [tgSessionString])
+
   const getMe = useCallback(
     async () => {
       if (!tgSessionString) return '0'
@@ -94,7 +92,7 @@ export const Provider = ({ children }: PropsWithChildren): ReactNode => {
   )
 
   return (
-    <Context.Provider value={[{ user, launchParams, dialogs, loadingDialogs, error}, { getMe }]}>
+    <Context.Provider value={[{ user, launchParams, dialogs, loadingDialogs, error}, { getMe, loadMoreDialogs }]}>
       {children}
     </Context.Provider>
   )


### PR DESCRIPTION
This PR updates the dialogs fetching logic. 
Instead of loading all dialogs at once on startup, dialogs are now loaded incrementally as the user scrolls down the page. 