### PR TITLE
feat: add x-client header

### DIFF
--- a/app/lib/server/constants.ts
+++ b/app/lib/server/constants.ts
@@ -106,12 +106,17 @@ export const receiptsEndpoint = new URL(
     die('NEXT_PUBLIC_STORACHA_RECEIPTS_URL')
 )
 
+const version = process.env.NEXT_PUBLIC_VERSION ?? '1.0.0'
+
 export const serviceConnection = connect<Service>({
   id: servicePrincipal,
   codec: CAR.outbound,
   channel: HTTP.open({
     url: serviceURL,
     method: 'POST',
+    headers: {
+      'X-Client': `Storacha/1 (js; browser) TelegramMiniapp/${version.split('.')[0]}`,
+    },
   }),
 })
 


### PR DESCRIPTION
This allows us to distinguish invocations made by this app vs others. Allows us to track the relative success of this application.

You may want to set `NEXT_PUBLIC_VERSION` environment var or load from `package.json` at some point...