### PR TITLE
fix: allow users to cancel a stuck backup

### DIFF
--- a/app/api.ts
+++ b/app/api.ts
@@ -59,6 +59,8 @@ export interface BaseJob {
   params: JobParams
   /** Timestamp of when this backup job was created. */
   created: number
+  /** Timestamp of when this backup job was last updated. */
+  updated: number
 }
 
 /** A backup job that is waiting to be queued and run. */
@@ -78,6 +80,8 @@ export interface CanceledJob extends BaseJob {
   progress?: number
   /** Timestamp of when this backup was started. I may not exist. */
   started?: number
+  /** Timestamp of when this backup was canceled. */
+  finished: number
 }
 
 /** A running backup job. */

--- a/app/components/dashboard/index.tsx
+++ b/app/components/dashboard/index.tsx
@@ -54,7 +54,7 @@ const JobItem = ({
   const progress =
     job.status === 'running' || job.status === 'failed' ? job.progress : 0
 
-  const STUCK_JOB_TIMEOUT_MS = 24 * 60 * 60 * 1000
+  const STUCK_JOB_TIMEOUT_MS = 3 * 60 * 60 * 1000
   const isStuck =
     (job.status === 'running' || job.status === 'waiting') &&
     Date.now() - job.updated > STUCK_JOB_TIMEOUT_MS

--- a/app/components/dashboard/index.tsx
+++ b/app/components/dashboard/index.tsx
@@ -57,7 +57,7 @@ const JobItem = ({
   const STUCK_JOB_TIMEOUT_MS = 24 * 60 * 60 * 1000
   const isStuck =
     (job.status === 'running' || job.status === 'waiting') &&
-    Date.now() - job.created > STUCK_JOB_TIMEOUT_MS
+    Date.now() - job.updated > STUCK_JOB_TIMEOUT_MS
 
   const DialogsLength = Object.keys(job.params.dialogs).length
 

--- a/app/components/root.tsx
+++ b/app/components/root.tsx
@@ -22,7 +22,14 @@ import { JobStorage } from '@/api'
 import Onboarding from '@/components/onboarding'
 import TelegramAuth from '@/components/telegram-auth'
 import { useGlobal } from '@/zustand/global'
-import { createJob, findJob, listJobs, login, removeJob } from './server'
+import {
+  createJob,
+  findJob,
+  listJobs,
+  login,
+  removeJob,
+  cancelJob,
+} from './server'
 import { create as createJobStorage } from '@/lib/store/jobs'
 import { StringSession, StoreSession } from '@/vendor/telegram/sessions'
 import { fromResult, getErrorMessage } from '@/lib/errorhandling'
@@ -107,22 +114,22 @@ const BackupProviderContainer = ({ children }: PropsWithChildren) => {
   useEffect(() => {
     let eventSource: EventSource
 
-		(async () => {
-			let encryptionPassword = await cloudStorage.getItem('encryption-password')
+    ;(async () => {
+      let encryptionPassword = await cloudStorage.getItem('encryption-password')
       console.log('encryption password: ', encryptionPassword)
-			setIsFirstLogin(!encryptionPassword)
-		
-			if (!storacha || !tgSessionString || !isStorachaAuthorized || !space) {
-				return
-			}
-		
-			if (!encryptionPassword) {
-				console.log('creating new encryption password')
-				encryptionPassword = generateRandomPassword()
-				await cloudStorage.setItem('encryption-password', encryptionPassword)
-			} else {
-				console.log('found existing encryption password')
-			}
+      setIsFirstLogin(!encryptionPassword)
+
+      if (!storacha || !tgSessionString || !isStorachaAuthorized || !space) {
+        return
+      }
+
+      if (!encryptionPassword) {
+        console.log('creating new encryption password')
+        encryptionPassword = generateRandomPassword()
+        await cloudStorage.setItem('encryption-password', encryptionPassword)
+      } else {
+        console.log('found existing encryption password')
+      }
 
       await storacha.setCurrentSpace(space)
 
@@ -150,6 +157,7 @@ const BackupProviderContainer = ({ children }: PropsWithChildren) => {
           findJob: async (jr) => fromResult(await findJob(jr)),
           listJobs: async (jr) => fromResult(await listJobs(jr)),
           removeJob: async (jr) => fromResult(await removeJob(jr)),
+          cancelJob: async (jr) => fromResult(await cancelJob(jr)),
         },
       })
       // setup a remove listener for async updates

--- a/app/components/server.ts
+++ b/app/components/server.ts
@@ -27,6 +27,7 @@ import {
   findJob as jobsFindJob,
   listJobs as jobsListJob,
   removeJob as jobsRemoveJob,
+  cancelJob as jobsCancelJob,
 } from '@/lib/server/jobs'
 import { SpaceDID } from '@storacha/access'
 import { toEntityData } from '@/lib/server/runner'
@@ -66,6 +67,7 @@ export const createJob = toResultFn(
 export const findJob = toResultFn(jobsFindJob)
 export const listJobs = toResultFn(jobsListJob)
 export const removeJob = toResultFn(jobsRemoveJob)
+export const cancelJob = toResultFn(jobsCancelJob)
 
 const withClient = <T extends [...unknown[]], U>(
   fn: (client: TelegramClient, ...args: T) => Promise<U>

--- a/app/lib/server/handler.ts
+++ b/app/lib/server/handler.ts
@@ -52,6 +52,7 @@ class Handler {
         created,
         started,
         progress,
+        updated: Date.now(),
       })
 
       let dialogsRetrieved = 0
@@ -76,6 +77,7 @@ class Handler {
               created,
               started,
               progress,
+              updated: Date.now(),
             })
           } catch (err) {
             console.error(err)
@@ -97,6 +99,7 @@ class Handler {
         created,
         started,
         finished: Date.now(),
+        updated: Date.now(),
       })
     } catch (err) {
       console.error('backup failed', err)
@@ -109,6 +112,7 @@ class Handler {
         created,
         started,
         finished: Date.now(),
+        updated: Date.now(),
       })
     }
   }

--- a/app/lib/server/handler.ts
+++ b/app/lib/server/handler.ts
@@ -59,6 +59,15 @@ class Handler {
         onDialogRetrieved: async () => {
           dialogsRetrieved++
           try {
+            const job = await this.#db.getJobByID(
+              request.jobID,
+              this.#dbUser.id
+            )
+            if (job.status === 'canceled') {
+              console.warn(`Job ${id} was canceled`)
+              return
+            }
+
             progress = dialogsRetrieved / Object.keys(dialogs).length / 2.1
             await this.#db.updateJob(id, {
               id,

--- a/app/lib/server/jobs.ts
+++ b/app/lib/server/jobs.ts
@@ -105,6 +105,24 @@ export const removeJob = async (request: RemoveJobRequest) => {
   return job
 }
 
+export const cancelJob = async (request: RemoveJobRequest) => {
+  console.debug('job store canceling job...')
+  const session = await getSession()
+  const telegramId = getTelegramId(session.telegramAuth)
+  const db = getDB()
+  const dbUser = await db.findOrCreateUser({
+    storachaSpace: session.spaceDID,
+    telegramId: telegramId.toString(),
+  })
+  const job = await db.getJobByID(request.jobID, dbUser.id)
+  await db.updateJob(request.jobID, {
+    ...job,
+    status: 'canceled',
+  })
+  console.debug(`job store canceled job: ${job.id}`)
+  return job
+}
+
 export const handleJob = async (request: ExecuteJobRequest) => {
   const handler = await initializeHandler(request)
   try {

--- a/app/lib/server/jobs.ts
+++ b/app/lib/server/jobs.ts
@@ -6,6 +6,7 @@ import {
   FindJobRequest,
   RemoveJobRequest,
   LoginRequest,
+  CancelJobRequest,
 } from '@/api'
 import { Delegation, DID, Signer } from '@ucanto/client'
 import { Client as StorachaClient } from '@storacha/client'
@@ -105,7 +106,7 @@ export const removeJob = async (request: RemoveJobRequest) => {
   return job
 }
 
-export const cancelJob = async (request: RemoveJobRequest) => {
+export const cancelJob = async (request: CancelJobRequest) => {
   console.debug('job store canceling job...')
   const session = await getSession()
   const telegramId = getTelegramId(session.telegramAuth)
@@ -118,6 +119,8 @@ export const cancelJob = async (request: RemoveJobRequest) => {
   await db.updateJob(request.jobID, {
     ...job,
     status: 'canceled',
+    updated: Date.now(),
+    finished: Date.now(),
   })
   console.debug(`job store canceled job: ${job.id}`)
   return job

--- a/app/lib/store/jobs.ts
+++ b/app/lib/store/jobs.ts
@@ -100,4 +100,13 @@ class Store extends EventTarget implements JobStorage {
     this.target.dispatchEvent(new CustomEvent('remove', { detail: job }))
     console.debug(`job store removed job: ${job.id}`)
   }
+
+  async cancel(id: JobID) {
+    console.debug('job store canceling job...')
+    const job = await this.#jobClient.cancelJob({
+      jobID: id,
+    })
+    this.target.dispatchEvent(new CustomEvent('remove', { detail: job }))
+    console.debug(`job store canceled job: ${job.id}`)
+  }
 }

--- a/app/lib/store/jobs.ts
+++ b/app/lib/store/jobs.ts
@@ -106,7 +106,7 @@ class Store extends EventTarget implements JobStorage {
     const job = await this.#jobClient.cancelJob({
       jobID: id,
     })
-    this.target.dispatchEvent(new CustomEvent('remove', { detail: job }))
+    this.target.dispatchEvent(new CustomEvent('cancel', { detail: job }))
     console.debug(`job store canceled job: ${job.id}`)
   }
 }

--- a/app/providers/backup.tsx
+++ b/app/providers/backup.tsx
@@ -66,6 +66,7 @@ export interface ContextActions {
     limit: number
   ) => Promise<void>
   fetchMoreMessages: (offset: number, limit: number) => Promise<void>
+  cancelBackupJob: (job: JobID) => Promise<void>
   // setBackup: (id: Link|null) => void
   // setDialog: (id: bigint | null) => void
 }
@@ -86,6 +87,7 @@ export const ContextDefaultValue: ContextValue = [
     removeBackupJob: () => Promise.reject(new Error('provider not setup')),
     restoreBackup: () => Promise.reject(new Error('provider not setup')),
     fetchMoreMessages: () => Promise.reject(new Error('provider not setup')),
+    cancelBackupJob: () => Promise.reject(new Error('provider not setup')),
     // setBackup: () => {},
     // setDialog: () => {}
   },
@@ -245,6 +247,23 @@ export const Provider = ({
     [jobStore]
   )
 
+  const cancelBackupJob = useCallback(
+    async (id: JobID) => {
+      if (!jobStore) {
+        setError('missing job store')
+        return
+      }
+      try {
+        await jobStore.cancel(id)
+      } catch (error: any) {
+        const msg = 'Error canceling backup job!'
+        console.error(msg, error)
+        setError(getErrorMessage(error), { title: msg })
+      }
+    },
+    [jobStore]
+  )
+
   useEffect(() => {
     if (!jobStore) return
 
@@ -310,7 +329,13 @@ export const Provider = ({
           restoredBackup: restoreBackupResult,
           jobsReady,
         },
-        { addBackupJob, removeBackupJob, restoreBackup, fetchMoreMessages },
+        {
+          addBackupJob,
+          removeBackupJob,
+          restoreBackup,
+          fetchMoreMessages,
+          cancelBackupJob,
+        },
       ]}
     >
       {children}

--- a/app/scripts/migrations/00006_add_new_status_to_jobs/index.sql
+++ b/app/scripts/migrations/00006_add_new_status_to_jobs/index.sql
@@ -1,10 +1,15 @@
 /**
-    Migration: Add 'canceled' status to the 'jobs' table.
+    Migration: Add 'canceled' status to the 'jobs' table and add 'updated_at' column.
 
-    This migration alters the 'jobs' table to allow jobs to have a new status: 'canceled'.
+    This migration alters the 'jobs' table to allow jobs to have a new status: 'canceled'
+    and adds an 'updated_at' timestamp column.
 */
+
 ALTER TABLE jobs DROP CONSTRAINT IF EXISTS jobs_status_check;
 
 ALTER TABLE jobs
   ADD CONSTRAINT jobs_status_check
   CHECK (status IN ('waiting','queued','running','failed','completed','canceled'));
+
+ALTER TABLE jobs
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP NOT NULL;

--- a/app/scripts/migrations/00006_add_new_status_to_jobs/index.sql
+++ b/app/scripts/migrations/00006_add_new_status_to_jobs/index.sql
@@ -1,0 +1,10 @@
+/**
+    Migration: Add 'canceled' status to the 'jobs' table.
+
+    This migration alters the 'jobs' table to allow jobs to have a new status: 'canceled'.
+*/
+ALTER TABLE jobs DROP CONSTRAINT IF EXISTS jobs_status_check;
+
+ALTER TABLE jobs
+  ADD CONSTRAINT jobs_status_check
+  CHECK (status IN ('waiting','queued','running','failed','completed','canceled'));


### PR DESCRIPTION
This PR introduces the ability for users to cancel backup jobs that have been in the `waiting` or `running` state for more than 24 hours (we can change this number if needed).
This does not actually remove or stop the job in the processing queue. Jobs marked as `canceled` are simply hidden from the UI.

- Users can now see a cancel (X) button for jobs stuck in `waiting` or `running` status for over a day.
- Canceling a job updates its status to `canceled` in the DB.

