### PR TITLE
fix(deploy): update storoku, no replicaiton conf

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -59,9 +59,9 @@ env:
   TF_VAR_telegram_bot_token: ${{ secrets.telegram-bot-token }}
   TF_VAR_next_public_telegram_api_id: ${{ secrets.next-public-telegram-api-id }}
   TF_VAR_next_public_telegram_api_hash: ${{ secrets.next-public-telegram-api-hash }}
-  TF_VAR_next_public_humanode_client_id: ${{ secrets.next-public-humanode-client-id }}
   TF_VAR_next_public_humanode_auth_url: ${{ secrets.next-public-humanode-auth-url }}
   TF_VAR_next_public_humanode_oauth_callback_url: ${{ secrets.next-public-humanode-oauth-callback-url }}
+  TF_VAR_next_public_humanode_client_id: ${{ secrets.next-public-humanode-client-id }}
   TF_VAR_cloudflare_zone_id: ${{ secrets.cloudflare-zone-id }}
   CLOUDFLARE_API_TOKEN: ${{ secrets.cloudflare-api-token }}
   DEPLOY_ENV: ci

--- a/.storoku.json
+++ b/.storoku.json
@@ -45,6 +45,18 @@
     {
       "name": "SESSION_PASSWORD",
       "variable": false
+    },
+    {
+      "name": "NEXT_PUBLIC_HUMANODE_AUTH_URL",
+      "variable": true
+    },
+    {
+      "name": "NEXT_PUBLIC_HUMANODE_OAUTH_CALLBACK_URL",
+      "variable": true
+    },
+    {
+      "name": "NEXT_PUBLIC_HUMANODE_CLIENT_ID",
+      "variable": true
     }
   ],
   "tables": null,

--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -52,7 +52,7 @@ resource "random_password" "session_password" {
 
 
 module "app" {
-  source = "github.com/storacha/storoku//app?ref=v0.2.40"
+  source = "github.com/storacha/storoku//app?ref=v0.2.41"
   private_key = var.private_key
   private_key_env_var = "SERVER_IDENTITY_PRIVATE_KEY"
   httpport = 3000
@@ -77,6 +77,9 @@ module "app" {
     "NEXT_PUBLIC_TELEGRAM_API_HASH" = var.next_public_telegram_api_hash
     "BACKUP_PASSWORD" = random_password.backup_password.result
     "SESSION_PASSWORD" = random_password.session_password.result
+    "NEXT_PUBLIC_HUMANODE_AUTH_URL" = var.next_public_humanode_auth_url
+    "NEXT_PUBLIC_HUMANODE_OAUTH_CALLBACK_URL" = var.next_public_humanode_oauth_callback_url
+    "NEXT_PUBLIC_HUMANODE_CLIENT_ID" = var.next_public_humanode_client_id
   }
   # enter any sqs queues you want to create here
   queues = [

--- a/deploy/app/variables.tf
+++ b/deploy/app/variables.tf
@@ -59,3 +59,18 @@ variable "next_public_telegram_api_hash" {
   description = "value for next_public_telegram_api_hash secret"
   type = string
 }
+
+variable "next_public_humanode_auth_url" {
+  description = "value for next_public_humanode_auth_url secret"
+  type = string
+}
+
+variable "next_public_humanode_oauth_callback_url" {
+  description = "value for next_public_humanode_oauth_callback_url secret"
+  type = string
+}
+
+variable "next_public_humanode_client_id" {
+  description = "value for next_public_humanode_client_id secret"
+  type = string
+}

--- a/deploy/shared/main.tf
+++ b/deploy/shared/main.tf
@@ -33,7 +33,7 @@ provider "aws" {
 }
 
 module "shared" {
-  source = "github.com/storacha/storoku//shared?ref=v0.2.40"
+  source = "github.com/storacha/storoku//shared?ref=v0.2.41"
   create_db = true
   caches = [  ]
   app = var.app


### PR DESCRIPTION
# Goals

Fix staging deploy

# Implementation

The root issue is that bluesky and telegram were overwriting each other's replication configs, which turns out to a single per region conf. It's now managed manually for now.

Also mods previous PR to add envs to storoku config for automatic generation