### PR TITLE
perf: recover backed up chat messages in batches

### DIFF
--- a/app/api.ts
+++ b/app/api.ts
@@ -231,6 +231,10 @@ export interface BackupData {
   period: AbsolutePeriod
 }
 
+export type DialogDataMessages = Array<
+  Link<EncryptedTaggedByteView<Array<MessageData | ServiceMessageData>>>
+>
+
 export interface DialogData extends EntityData {
   /** A link to the entities that participated in this dialog. */
   entities: Link<EncryptedTaggedByteView<EntityRecordData>>
@@ -242,9 +246,7 @@ export interface DialogData extends EntityData {
    *
    * Each list has a maximum of 1,000 messages.
    */
-  messages: Array<
-    Link<EncryptedTaggedByteView<Array<MessageData | ServiceMessageData>>>
-  >
+  messages: DialogDataMessages
 }
 
 export interface DialogInfo extends EntityData {
@@ -1357,6 +1359,9 @@ export interface RestoredBackup {
   mediaMap: Record<string, Uint8Array>
   participants: Record<string, EntityData>
   hasMoreMessages: boolean
+  isLoadingMore?: boolean
+  lastBatchIndex: number
+  lastMessageIndex: number
 }
 
 export type MediaData =

--- a/app/app/dialog/[id]/backup/[cid]/page.tsx
+++ b/app/app/dialog/[id]/backup/[cid]/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { Fragment, useEffect, useRef, useState } from 'react'
+import { Fragment, useEffect, useMemo, useRef, useState } from 'react'
 import { useTelegram } from '@/providers/telegram'
 import { useParams, useRouter, useSearchParams } from 'next/navigation'
 
@@ -290,9 +290,12 @@ export default function Page() {
   const type = searchParams.get('type') as EntityType
   const [userId, setUserId] = useState<string>()
 
-  useEffect(() => {
-    const normalizedId = getNormalizedEntityId(id, type)
+  const normalizedId = useMemo(
+    () => getNormalizedEntityId(id, type),
+    [id, type]
+  )
 
+  useEffect(() => {
     const fetchBackup = async () => {
       const userId = await getMe()
       if (!userId) return
@@ -301,7 +304,7 @@ export default function Page() {
     }
 
     fetchBackup()
-  }, [backupCid, id, restoreBackup, getMe, type])
+  }, [backupCid, restoreBackup, getMe])
 
   const handleFetchMoreMessages = async () => {
     if (

--- a/app/app/dialog/[id]/backup/[cid]/page.tsx
+++ b/app/app/dialog/[id]/backup/[cid]/page.tsx
@@ -230,9 +230,11 @@ function BackupDialog({
                 msg.media.metadata.type === 'document'
                   ? msg.media.metadata.document?.mimeType
                   : ''
-              mediaUrl = URL.createObjectURL(
-                new Blob([rawContent], { type: type })
-              )
+              if (rawContent) {
+                mediaUrl = URL.createObjectURL(
+                  new Blob([rawContent], { type: type })
+                )
+              }
             }
 
             return (

--- a/app/app/dialog/[id]/backup/[cid]/page.tsx
+++ b/app/app/dialog/[id]/backup/[cid]/page.tsx
@@ -28,7 +28,7 @@ type BackupDialogProps = {
   messages: (MessageData | ServiceMessageData)[]
   mediaMap: Record<string, Uint8Array>
   participants: Record<string, EntityData>
-  onScrollTop: () => void
+  onScrollBottom: () => Promise<void>
 }
 
 const formatTime = (timestamp: number) =>
@@ -142,10 +142,10 @@ function BackupDialog({
   messages,
   mediaMap,
   participants,
-  onScrollTop,
+  onScrollBottom,
 }: BackupDialogProps) {
   const chatContainerRef = useRef<HTMLDivElement>(null)
-  const sortedMessages = [...messages].sort((a, b) => a.date - b.date)
+  const [isLoadingMore, setIsLoadingMore] = useState(false)
   let lastRenderedDate: string | null = null
   let lastSenderId: string | null = null
 
@@ -157,25 +157,37 @@ function BackupDialog({
   }
 
   useEffect(() => {
-    const handleScroll = () => {
-      if (chatContainerRef.current) {
-        const { scrollTop } = chatContainerRef.current
-        if (scrollTop === 0) {
-          onScrollTop()
+    const handleScroll = async () => {
+      if (chatContainerRef.current && !isLoadingMore) {
+        const { scrollTop, scrollHeight, clientHeight } =
+          chatContainerRef.current
+        const scrolledToBottom = scrollTop + clientHeight >= scrollHeight - 20
+
+        if (scrolledToBottom) {
+          setIsLoadingMore(true)
+          await onScrollBottom()
+          setIsLoadingMore(false)
         }
       }
     }
 
     const chatContainer = chatContainerRef.current
-    chatContainer?.addEventListener('scroll', handleScroll)
+    if (chatContainer) {
+      chatContainer.addEventListener('scroll', handleScroll, { passive: true })
+
+      // Also check scroll position on mount and when messages change
+      handleScroll()
+    }
 
     return () => {
-      chatContainer?.removeEventListener('scroll', handleScroll)
+      if (chatContainer) {
+        chatContainer.removeEventListener('scroll', handleScroll)
+      }
     }
-  }, [onScrollTop])
+  }, [onScrollBottom, isLoadingMore, messages.length])
 
   return (
-    <div className="flex flex-col bg-background">
+    <div className="flex flex-col bg-background h-screen">
       <ChatHeader
         image={dialogThumbSrc}
         name={dialog.name}
@@ -184,9 +196,10 @@ function BackupDialog({
       <div
         ref={chatContainerRef}
         className="flex-1 overflow-y-auto px-4 py-6 space-y-4"
+        style={{ height: 'calc(100vh - 64px)' }} // Ensure proper height
       >
-        {sortedMessages
-          .filter((msg) => msg.type !== 'service') // TODO: handle this
+        {messages
+          .filter((msg) => msg.type !== 'service')
           .map((msg) => {
             const date = formatDate(msg.date)
             const showDate = lastRenderedDate !== date
@@ -195,7 +208,7 @@ function BackupDialog({
             const isOutgoing = msg.from === userId
 
             const sender = msg.from
-              ? participants[msg.from]?.name ?? 'Unknown'
+              ? (participants[msg.from]?.name ?? 'Unknown')
               : 'Anonymous'
 
             const showSenderHeader = !isOutgoing && lastSenderId !== msg.from
@@ -257,6 +270,11 @@ function BackupDialog({
               </Fragment>
             )
           })}
+        {isLoadingMore && (
+          <div className="text-center py-4">
+            <Loading text="Loading more messages..." />
+          </div>
+        )}
       </div>
     </div>
   )
@@ -279,14 +297,20 @@ export default function Page() {
       const userId = await getMe()
       if (!userId) return
       setUserId(userId)
-      await restoreBackup(backupCid!, normalizedId, 50)
+      await restoreBackup(backupCid!, normalizedId, 20)
     }
 
     fetchBackup()
-  }, [backupCid, id, restoreBackup, getMe])
+  }, [backupCid, id, restoreBackup, getMe, type])
 
   const handleFetchMoreMessages = async () => {
-    return fetchMoreMessages(restoredBackup.item?.messages.length || 0, 50)
+    if (
+      restoredBackup.item?.hasMoreMessages &&
+      !restoredBackup.item?.isLoadingMore
+    ) {
+      console.log('Fetching more messages...')
+      await fetchMoreMessages(30)
+    }
   }
 
   return (
@@ -302,7 +326,7 @@ export default function Page() {
       {restoredBackup.loading || !userId ? (
         <div className="flex flex-col items-center justify-center h-screen">
           <div className="text-lg font-semibold text-center">
-            <Loading />
+            <Loading text="Loading messages..." />
           </div>
         </div>
       ) : restoredBackup.item ? (
@@ -312,7 +336,7 @@ export default function Page() {
           messages={restoredBackup.item.messages}
           mediaMap={restoredBackup.item.mediaMap}
           participants={restoredBackup.item.participants}
-          onScrollTop={handleFetchMoreMessages}
+          onScrollBottom={handleFetchMoreMessages}
         />
       ) : (
         <div className="flex flex-col items-center justify-center h-screen">

--- a/app/components/ui/media.tsx
+++ b/app/components/ui/media.tsx
@@ -1,7 +1,14 @@
 'use client'
 
 import React, { useState } from 'react'
-import { File, MapPin, CheckCircle, ExternalLink, X } from 'lucide-react'
+import {
+  File,
+  MapPin,
+  CheckCircle,
+  ExternalLink,
+  X,
+  Loader2,
+} from 'lucide-react'
 import { Document, Page, pdfjs } from 'react-pdf'
 import { decodeStrippedThumb, toJPGDataURL, cn } from '@/lib/utils'
 import {
@@ -143,14 +150,15 @@ const Bubble: React.FC<{ children: React.ReactNode }> = ({ children }) => (
   <div className="p-3 bg-gray-100 rounded-xl max-w-sm">{children}</div>
 )
 
-const PlaceholderBubble: React.FC<{ label: string }> = ({ label }) => (
-  <div className="flex items-center justify-center w-full h-32 bg-gray-200 text-gray-500 text-sm rounded-xl">
-    {label}
+const PlaceholderBubble: React.FC<{ label?: string }> = ({ label }) => (
+  <div className="flex flex-col items-center justify-center w-full h-32 min-w-[8rem] min-h-[10rem] bg-gray-200 text-gray-500 text-sm rounded-xl">
+    <Loader2 className="animate-spin h-7 w-7 text-gray-400 mb-2" />
+    {label ?? <p className="px-4">{label}</p>}
   </div>
 )
 
 const ImageMedia: React.FC<{ mediaUrl?: string }> = ({ mediaUrl }) => {
-  if (!mediaUrl) return <PlaceholderBubble label="No image available" />
+  if (!mediaUrl) return <PlaceholderBubble label="no image" />
   return (
     <div className="flex justify-center">
       <img
@@ -174,7 +182,7 @@ const AudioMedia: React.FC<{
   const mime = metadata.document?.mimeType || 'audio/mpeg'
 
   if (!mediaUrl)
-    return <div className="p-2 text-sm text-gray-500">No audio available</div>
+    return <div className="p-2 text-sm text-gray-500">loading audio...</div>
 
   return (
     <div className="w-full max-w-sm mx-auto space-y-2">
@@ -202,7 +210,7 @@ const VideoMedia: React.FC<{
   mediaUrl?: string
   metadata: DocumentMediaData
 }> = ({ mediaUrl, metadata }) => {
-  if (!mediaUrl) return <PlaceholderBubble label="No video available" />
+  if (!mediaUrl) return <PlaceholderBubble label="no video" />
 
   const mime = metadata.document?.mimeType?.toLowerCase() || 'video/mp4'
   const thumbUrl = metadata.document
@@ -225,7 +233,7 @@ const GifMedia: React.FC<{
   mediaUrl?: string
   metadata?: DocumentMediaData
 }> = ({ mediaUrl, metadata }) => {
-  if (!mediaUrl) return <PlaceholderBubble label="No video available" />
+  if (!mediaUrl) return <PlaceholderBubble label="no gif" />
 
   const mime = metadata?.document?.mimeType?.toLowerCase() || 'video/mp4'
 

--- a/app/lib/backup/recoverer.ts
+++ b/app/lib/backup/recoverer.ts
@@ -5,6 +5,7 @@ import {
   BackupModel,
   Decrypter,
   DialogData,
+  DialogDataMessages,
   EntityData,
   MessageData,
   RestoredBackup,
@@ -28,7 +29,7 @@ export const restoreBackup = async (
   backupCid: string,
   dialogId: string,
   cipher: Decrypter,
-  limit: number = 50
+  limit: number = 20
 ): Promise<RestoredBackup> => {
   const response = await getFromStoracha(backupCid)
   const encryptedBackupRaw = new Uint8Array(await response.arrayBuffer())
@@ -49,83 +50,68 @@ export const restoreBackup = async (
     encryptedDialogData
   )) as DialogData
 
-  const messagesToFetch = decryptedDialogData.messages.slice(0, limit)
-  const hasMoreMessages = decryptedDialogData.messages.length > limit
+  // Load entities first (needed for all messages)
+  const entitiesResult = await getFromStoracha(
+    decryptedDialogData.entities.toString()
+  )
+  const encryptedEntitiesData = new Uint8Array(
+    await entitiesResult.arrayBuffer()
+  )
+  const restoredEntities = (await Crypto.decryptAndDecode(
+    cipher,
+    dagCBOR,
+    encryptedEntitiesData
+  )) as Record<string, EntityData>
 
+  // Load initial messages progressively
   const mediaMap: Record<string, Uint8Array> = {}
-
-  const [restoredMessages, restoredEntities] = await Promise.all([
-    // Fetch and decrypt messages
-    (async () => {
-      const messages: MessageData[] = []
-      for (const messageLink of messagesToFetch) {
-        const messagesResult = await getFromStoracha(messageLink.toString())
-        const encryptedMessageData = new Uint8Array(
-          await messagesResult.arrayBuffer()
-        )
-        const decryptedMessageData = (await Crypto.decryptAndDecode(
-          cipher,
-          dagCBOR,
-          encryptedMessageData
-        )) as MessageData[]
-
-        for (const message of decryptedMessageData) {
-          if (message.media?.content) {
-            const mediaCid = message.media.content.toString()
-            if (!mediaMap[mediaCid]) {
-              const mediaResult = await getFromStoracha(mediaCid)
-              const encryptedRawMedia = new Uint8Array(
-                await mediaResult.arrayBuffer()
-              )
-              const rawMedia = await Crypto.decryptAndDecode(
-                cipher,
-                raw,
-                encryptedRawMedia
-              )
-              mediaMap[mediaCid] = rawMedia
-            }
-          }
-          messages.push(message)
-        }
-      }
-      return messages
-    })(),
-
-    // Fetch and decrypt entities
-    (async () => {
-      const entitiesResult = await getFromStoracha(
-        decryptedDialogData.entities.toString()
-      )
-      const encryptedEntitiesData = new Uint8Array(
-        await entitiesResult.arrayBuffer()
-      )
-      return (await Crypto.decryptAndDecode(
-        cipher,
-        dagCBOR,
-        encryptedEntitiesData
-      )) as Record<string, EntityData>
-    })(),
-  ])
+  const {
+    messages: initialMessages,
+    lastBatchIndex,
+    lastMessageIndex,
+    hasMoreMessages,
+  } = await loadMessagesProgressively(
+    decryptedDialogData.messages,
+    cipher,
+    mediaMap,
+    0,
+    0,
+    limit
+  )
 
   return {
     dialogData: decryptedDialogData,
-    messages: restoredMessages,
+    messages: initialMessages,
     participants: restoredEntities,
     mediaMap,
     hasMoreMessages,
+    lastBatchIndex,
+    lastMessageIndex,
   }
 }
 
-export const fetchMoreMessages = async (
-  dialogData: DialogData,
-  cipher: Decrypter,
-  offset: number,
-  limit: number
-) => {
-  const newMessages: MessageData[] = []
-  const messagesToFetch = dialogData.messages.slice(offset, offset + limit)
+interface LoadResult {
+  messages: MessageData[]
+  lastBatchIndex: number
+  lastMessageIndex: number
+  hasMoreMessages: boolean
+}
 
-  for (const messageLink of messagesToFetch) {
+const loadMessagesProgressively = async (
+  messageBatches: DialogDataMessages,
+  cipher: Decrypter,
+  mediaMap: Record<string, Uint8Array>,
+  startBatchIndex: number,
+  startMessageIndex: number,
+  limit: number
+): Promise<LoadResult> => {
+  const messages: MessageData[] = []
+  let currentBatchIndex = startBatchIndex
+  let currentMessageIndex = startMessageIndex
+  let loadedCount = 0
+
+  while (currentBatchIndex < messageBatches.length && loadedCount < limit) {
+    const messageLink = messageBatches[currentBatchIndex]
     const messagesResult = await getFromStoracha(messageLink.toString())
     const encryptedMessageData = new Uint8Array(
       await messagesResult.arrayBuffer()
@@ -135,8 +121,86 @@ export const fetchMoreMessages = async (
       dagCBOR,
       encryptedMessageData
     )) as MessageData[]
-    newMessages.push(...decryptedMessageData)
+
+    // Load messages from current index in this batch
+    const remainingInBatch = decryptedMessageData.length - currentMessageIndex
+    const toLoadFromBatch = Math.min(remainingInBatch, limit - loadedCount)
+
+    const batchMessages = decryptedMessageData.slice(
+      currentMessageIndex,
+      currentMessageIndex + toLoadFromBatch
+    )
+
+    // Load media for these messages
+    for (const message of batchMessages) {
+      if (message.media?.content) {
+        const mediaCid = message.media.content.toString()
+        if (!mediaMap[mediaCid]) {
+          try {
+            const mediaResult = await getFromStoracha(mediaCid)
+            const encryptedRawMedia = new Uint8Array(
+              await mediaResult.arrayBuffer()
+            )
+            const rawMedia = await Crypto.decryptAndDecode(
+              cipher,
+              raw,
+              encryptedRawMedia
+            )
+            mediaMap[mediaCid] = rawMedia
+          } catch (error) {
+            console.warn(`Failed to load media ${mediaCid}:`, error)
+          }
+        }
+      }
+    }
+
+    messages.push(...batchMessages)
+    loadedCount += batchMessages.length
+
+    // Update indices
+    currentMessageIndex += toLoadFromBatch
+
+    // If we've finished this batch, move to next batch
+    if (currentMessageIndex >= decryptedMessageData.length) {
+      currentBatchIndex++
+      currentMessageIndex = 0
+    }
   }
 
-  return newMessages
+  const hasMoreMessages =
+    currentBatchIndex < messageBatches.length ||
+    (currentBatchIndex === messageBatches.length - 1 && currentMessageIndex > 0)
+
+  return {
+    messages,
+    lastBatchIndex: currentBatchIndex,
+    lastMessageIndex: currentMessageIndex,
+    hasMoreMessages,
+  }
+}
+
+export const fetchMoreMessages = async (
+  dialogDataMessages: DialogDataMessages,
+  cipher: Decrypter,
+  startBatchIndex: number,
+  startMessageIndex: number,
+  limit: number
+) => {
+  const mediaMap: Record<string, Uint8Array> = {}
+  const result = await loadMessagesProgressively(
+    dialogDataMessages,
+    cipher,
+    mediaMap,
+    startBatchIndex,
+    startMessageIndex,
+    limit
+  )
+
+  return {
+    messages: result.messages,
+    mediaMap,
+    lastBatchIndex: result.lastBatchIndex,
+    lastMessageIndex: result.lastMessageIndex,
+    hasMoreMessages: result.hasMoreMessages,
+  }
 }

--- a/app/package.json
+++ b/app/package.json
@@ -57,6 +57,7 @@
     "multiformats": "^13.3.2",
     "next": "15.3.0-canary.33",
     "node-cache": "^5.1.2",
+    "p-map": "^7.0.3",
     "p-queue": "^8.1.0",
     "postgres": "^3.4.7",
     "postgres-shift": "^0.1.0",

--- a/app/package.json
+++ b/app/package.json
@@ -52,6 +52,7 @@
     "input-otp": "^1.4.2",
     "iron-session": "^8.0.4",
     "jsonwebtoken": "^9.0.2",
+    "lru-cache": "^11.1.0",
     "lucide-react": "^0.469.0",
     "mongoose": "^8.10.1",
     "multiformats": "^13.3.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -149,6 +149,9 @@ importers:
       node-cache:
         specifier: ^5.1.2
         version: 5.1.2
+      p-map:
+        specifier: ^7.0.3
+        version: 7.0.3
       p-queue:
         specifier: ^8.1.0
         version: 8.1.0
@@ -6054,6 +6057,10 @@ packages:
   p-locate@5.0.0:
     resolution: {integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==}
     engines: {node: '>=10'}
+
+  p-map@7.0.3:
+    resolution: {integrity: sha512-VkndIv2fIB99swvQoA65bm+fsmt6UNdGeIB0oxBs+WhAhdh08QA04JXpI7rbB9r08/nkbysKoya9rtDERYOYMA==}
+    engines: {node: '>=18'}
 
   p-queue@8.1.0:
     resolution: {integrity: sha512-mxLDbbGIBEXTJL0zEx8JIylaj3xQ7Z/7eEVjcF9fJX4DBiH9oqe+oahYnlKKxm0Ci9TlWTyhSHgygxMxjIB2jw==}
@@ -14886,6 +14893,8 @@ snapshots:
   p-locate@5.0.0:
     dependencies:
       p-limit: 3.1.0
+
+  p-map@7.0.3: {}
 
   p-queue@8.1.0:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -134,6 +134,9 @@ importers:
       jsonwebtoken:
         specifier: ^9.0.2
         version: 9.0.2
+      lru-cache:
+        specifier: ^11.1.0
+        version: 11.1.0
       lucide-react:
         specifier: ^0.469.0
         version: 0.469.0(react@19.0.0)
@@ -5587,6 +5590,10 @@ packages:
 
   lru-cache@10.4.3:
     resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lru-cache@11.1.0:
+    resolution: {integrity: sha512-QIXZUBJUx+2zHUdQujWejBkcD9+cs94tLn0+YL8UrCh+D5sCXZ4c7LaEH48pNwRY3MLDgqUFyhlCyjJPf1WP0A==}
+    engines: {node: 20 || >=22}
 
   lru-cache@5.1.1:
     resolution: {integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==}
@@ -14452,6 +14459,8 @@ snapshots:
       js-tokens: 4.0.0
 
   lru-cache@10.4.3: {}
+
+  lru-cache@11.1.0: {}
 
   lru-cache@5.1.1:
     dependencies:


### PR DESCRIPTION
This PR introduces an in-memory cache for the first few messages loaded by `restoreBackup` for each `backupCid:dialogId` pair, improving the speed and efficiency of opening chats. 

It also implements batch fetching for backup messages, allowing messages to be loaded in smaller chunks to improve performance and reduce initial load times.