### PR TITLE
fix: jobs progress

### DIFF
--- a/app/components/dashboard/index.tsx
+++ b/app/components/dashboard/index.tsx
@@ -7,7 +7,6 @@ import Head from '@/components/dashboard/head'
 import { Button } from '@/components/ui/button'
 import { StorachaConnect } from '@/components/backup/connect'
 import BackedChats from '@/components/dashboard/backed-chats'
-import { useEffect, useState } from 'react'
 
 export default function Dashboard() {
   const router = useRouter()
@@ -62,6 +61,15 @@ const JobItem = ({
 
   const DialogsLength = Object.keys(job.params.dialogs).length
 
+  const getProgressText = () => {
+    if (job.status === 'waiting') return 'Waiting to start...'
+    if (job.status === 'failed') return 'Failed'
+    if (progress === 0) return 'Starting...'
+    if (progress < 0.7) return 'Retrieving messages...'
+    if (progress < 0.95) return 'Storing backup...'
+    return 'Finishing up...'
+  }
+
   return (
     <div className="w-full px-5 mb-5">
       <div className="w-full bg-background rounded-sm border">
@@ -86,14 +94,14 @@ const JobItem = ({
         <div className="flex justify-between items-center px-3 py-3">
           <div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
             <div
-              className="bg-blue-900 h-2.5 rounded-full transition-[width] duration-300 ease-in-out"
-              style={{ width: `${progress * 100}%` }}
+              className="bg-blue-900 h-2.5 rounded-full transition-[width] duration-500 ease-out"
+              style={{ width: `${Math.max(progress * 100, 2)}%` }}
             ></div>
           </div>
         </div>
         <div className="flex justify-between items-center px-3 pb-4">
           <span className="text-muted-foreground text-xs">
-            {Math.floor(progress * 100)}% Completed
+            {Math.floor(progress * 100)}% - {getProgressText()}
           </span>
           <span className="text-muted-foreground text-xs">
             {DialogsLength} Chat{DialogsLength > 1 ? 's' : ''} Backing Up

--- a/app/components/dashboard/index.tsx
+++ b/app/components/dashboard/index.tsx
@@ -55,8 +55,6 @@ const JobItem = ({
   const progress =
     job.status === 'running' || job.status === 'failed' ? job.progress : 0
 
-  console.log('job progress', progress)
-
   const STUCK_JOB_TIMEOUT_MS = 3 * 60 * 60 * 1000
   const isStuck =
     (job.status === 'running' || job.status === 'waiting') &&
@@ -88,7 +86,7 @@ const JobItem = ({
         <div className="flex justify-between items-center px-3 py-3">
           <div className="w-full bg-gray-200 rounded-full h-2.5 dark:bg-gray-700">
             <div
-              className="bg-blue-900 h-2.5 rounded-full transition-all"
+              className="bg-blue-900 h-2.5 rounded-full transition-[width] duration-300 ease-in-out"
               style={{ width: `${progress * 100}%` }}
             ></div>
           </div>

--- a/app/components/dashboard/index.tsx
+++ b/app/components/dashboard/index.tsx
@@ -7,6 +7,7 @@ import Head from '@/components/dashboard/head'
 import { Button } from '@/components/ui/button'
 import { StorachaConnect } from '@/components/backup/connect'
 import BackedChats from '@/components/dashboard/backed-chats'
+import { useEffect, useState } from 'react'
 
 export default function Dashboard() {
   const router = useRouter()
@@ -53,6 +54,8 @@ const JobItem = ({
 }) => {
   const progress =
     job.status === 'running' || job.status === 'failed' ? job.progress : 0
+
+  console.log('job progress', progress)
 
   const STUCK_JOB_TIMEOUT_MS = 3 * 60 * 60 * 1000
   const isStuck =

--- a/app/lib/server/handler.ts
+++ b/app/lib/server/handler.ts
@@ -4,6 +4,7 @@ import * as Runner from './runner'
 import { TGDatabase, User } from './db'
 import { CARMetadata } from '@storacha/ui-react'
 import { mRachaPointsPerByte } from './constants'
+import { SHARD_SIZE } from '@storacha/upload-client'
 
 export interface Context extends RunnerContext {
   db: TGDatabase
@@ -43,10 +44,22 @@ class Handler {
       params: { space, dialogs, period },
     } = job
 
-    let progress = 0
     const started = Date.now()
     const totalDialogs = Object.keys(dialogs).length
+    let progress = 0
+    let dialogsRetrieved = 0
     let dialogsCompleted = 0
+    let totalBytesUploaded = 0
+
+    /**
+     * Calculates the progress of the backup job, excluding the final shard storage phase.
+     * - Dialog retrieval accounts for 20% of the total progress.
+     * - Message retrieval accounts for 50% of the total progress.
+     * @returns The current progress percentage of the backup job, excluding the last storage step.
+     */
+    const getDialogsProgress = () =>
+      (dialogsRetrieved / totalDialogs) * 0.2 +
+      (dialogsCompleted / totalDialogs) * 0.5
 
     try {
       await this.#db.updateJob(id, {
@@ -60,7 +73,10 @@ class Handler {
       })
 
       const data = await Runner.run(this, space, dialogs, period, {
-        onDialogRetrieved: async () => {
+        /**
+         * Called when a dialog entity is created and ready for processing
+         */
+        onDialogRetrieved: async (dialogId) => {
           try {
             const currentJob = await this.#db.getJobByID(
               request.jobID,
@@ -71,8 +87,9 @@ class Handler {
               return
             }
 
-            dialogsCompleted++
-            progress = Math.min(0.7, (dialogsCompleted / totalDialogs) * 0.1)
+            dialogsRetrieved++
+            progress = getDialogsProgress()
+
             await this.#db.updateJob(id, {
               id,
               status: 'running',
@@ -84,19 +101,55 @@ class Handler {
             })
           } catch (err) {
             console.error(
-              'Error updating progress during dialog retrieval:',
+              `Error updating progress during dialog ${dialogId.toString()} retrieval:`,
+              err
+            )
+          }
+        },
+
+        /**
+         * Called when all messages for a dialog have been retrieved
+         */
+        onMessagesRetrieved: async (dialogId) => {
+          try {
+            const currentJob = await this.#db.getJobByID(
+              request.jobID,
+              this.#dbUser.id
+            )
+            if (currentJob?.status === 'canceled') {
+              console.warn(`Job ${id} was canceled`)
+              return
+            }
+
+            dialogsCompleted++
+            progress = getDialogsProgress()
+
+            await this.#db.updateJob(id, {
+              id,
+              status: 'running',
+              params,
+              created,
+              started,
+              progress,
+              updated: Date.now(),
+            })
+          } catch (err) {
+            console.error(
+              `Error updating progress during messages retried for dialog ${dialogId.toString()}:`,
               err
             )
           }
         },
 
         onShardStored: async (meta: CARMetadata) => {
-          progress = Math.min(
-            1.0,
-            0.7 + (dialogsCompleted / totalDialogs) * 0.3
-          )
-
           try {
+            /**
+             * Called after all messages have been retrieved for all dialogs.
+             * If the total uploaded bytes are less than SHARD_SIZE, the backup job is considered complete.
+             */
+            totalBytesUploaded += meta.size
+            progress = totalBytesUploaded <= SHARD_SIZE ? 1 : 0.9
+
             await this.#db.updateJob(id, {
               id,
               status: 'running',

--- a/app/lib/server/runner.ts
+++ b/app/lib/server/runner.ts
@@ -79,6 +79,13 @@ export interface Options {
    * not yet stored.
    */
   onDialogRetrieved?: (id: bigint) => unknown
+  /**
+   * Called when all messages for a dialog have been retrieved
+   */
+  onMessagesRetrieved?: (id: bigint) => unknown
+  /**
+   * Called when a shard is stored, a dialog can have multiple shards.
+   */
   onShardStored?: (meta: CARMetadata) => unknown
 }
 
@@ -226,7 +233,9 @@ export const run = async (
 
         if (done) {
           messageIterator = null
-          await options?.onDialogRetrieved?.(BigInt(dialogEntity.id.toString()))
+          await options?.onMessagesRetrieved?.(
+            BigInt(dialogEntity.id.toString())
+          )
           break
         }
 

--- a/app/lib/server/runner.ts
+++ b/app/lib/server/runner.ts
@@ -134,6 +134,7 @@ export const run = async (
         }
 
         dialogEntity = { id: dialogID, ...dialogs[dialogID] }
+        await options?.onDialogRetrieved?.(BigInt(dialogID))
         const dialogInput =
           buildDialogInputPeer(dialogEntity) ?? bigInt(dialogID)
 
@@ -217,7 +218,6 @@ export const run = async (
                 minId: minMsgId,
               })
               [Symbol.asyncIterator]()
-
             ;({ value: message, done } = await messageIterator.next())
           } else {
             throw error

--- a/app/providers/backup.tsx
+++ b/app/providers/backup.tsx
@@ -108,10 +108,45 @@ export const Provider = ({
 }: ProviderProps): ReactNode => {
   const { setError } = useError()
   const [jobs, setJobs] = useState<PendingJob[]>([])
+  const [jobsProgress, setJobsProgress] = useState<Record<JobID, number>>({})
   const [jobsLoading, setJobsLoading] = useState(false)
   const [jobsError, setJobsError] = useState<Error>()
+
+  const interpolateJobsProgress = (job: PendingJob) => {
+    const start = jobsProgress[job.id] ?? 0
+    const end =
+      job.status === 'running' || job.status === 'failed' ? job.progress : 0
+    if (start >= end) return
+
+    const duration = 800
+    const startTime = performance.now()
+
+    const step = (now: number) => {
+      const elapsed = now - startTime
+      const t = Math.min(elapsed / duration, 1)
+      const eased = 1 - Math.pow(1 - t, 3)
+      const newProgress = start + (end - start) * eased
+
+      setJobsProgress((prev) => ({
+        ...prev,
+        [job.id]: newProgress,
+      }))
+
+      if (t < 1) {
+        requestAnimationFrame(step)
+      }
+    }
+
+    requestAnimationFrame(step)
+  }
+
+  // former progress value was just static at 0.47619047619047616 not changing
+  const jobsWithDynamicProgressValue = jobs.map((job) => ({
+    ...job,
+    progress: jobsProgress[job.id] ?? 0,
+  }))
   const jobsResult = {
-    items: jobs,
+    items: jobsWithDynamicProgressValue,
     loading: jobsLoading,
     error: jobsError,
   }
@@ -275,6 +310,7 @@ export const Provider = ({
         console.debug('listing pending jobs...')
         const jobs = await jobStore.listPending()
         console.debug(`found ${jobs.items.length} pending jobs`)
+        jobs.items.forEach(interpolateJobsProgress)
         setJobs(jobs.items)
       } catch (err: any) {
         console.error('Error: handling job change event', err)


### PR DESCRIPTION
the previous computation used a static value where progress is obtained by dividing the dialogs retrieved by 2.1, which led to a ~0.48 percentage cap

now, we're splitting it into two phases. one for the retrieval, 0.7 and the other 0.3 for shard storage