### PR TITLE
added wrong password error text

### DIFF
--- a/app/components/telegram-auth.tsx
+++ b/app/components/telegram-auth.tsx
@@ -311,7 +311,12 @@ export default function TelegramAuth() {
     } catch (err: any) {
       console.error('checking password:', err)
       await getSRP()
-      setError(err)
+      
+      if (err.errorMessage === 'PASSWORD_HASH_INVALID') {
+        setError(new Error('Your password was incorrect. Please try again.'))
+      } else {
+        setError(err)
+      }
     } finally {
       setLoading(false)
     }


### PR DESCRIPTION
## What was wrong

There was just internal error message but not helpful for the user since they do not know that the password was entered incorrectly or if the app does not work

Fixes #153 