### PR TITLE
fix: throw error on empty backup and add session validation

### DIFF
--- a/app/components/layouts/menu.tsx
+++ b/app/components/layouts/menu.tsx
@@ -16,7 +16,6 @@ export function Menu() {
   const [, { logout }] = useStoracha()
   const {
     phoneNumber,
-    setIsTgAuthorized,
     setIsStorachaAuthorized,
     setPhoneNumber,
     setSpace,
@@ -33,10 +32,6 @@ export function Menu() {
     setPhoneNumber('')
     setSpace(null)
     setTgSessionString('')
-    // TODO: remove other stuff in global?
-    // TODO: I don't think this actually does anything 😱
-    // There's no client logout method (there is in Python)
-    setIsTgAuthorized(false)
     await logout()
     setIsStorachaAuthorized(false)
   }

--- a/app/components/telegram-auth.tsx
+++ b/app/components/telegram-auth.tsx
@@ -181,14 +181,9 @@ export default function TelegramAuth() {
   const [error, setError] = useState<Error>()
   const [codeHash, setCodeHash] = useState('')
   const [code, setCode] = useState('')
-  const {
-    setIsTgAuthorized,
-    phoneNumber,
-    setPhoneNumber,
-    tgSessionString,
-    setTgSessionString,
-  } = useGlobal()
-  const [{ user }] = useTelegram()
+  const { phoneNumber, setPhoneNumber, tgSessionString, setTgSessionString } =
+    useGlobal()
+  const [{ user }, { setIsTgAuthorized }] = useTelegram()
   const [is2FARequired, set2FARequired] = useState(false)
   const [password, setPassword] = useState('')
   const [srp, setSRP] = useState<Api.account.Password>()

--- a/app/lib/server/runner.ts
+++ b/app/lib/server/runner.ts
@@ -217,7 +217,6 @@ export const run = async (
                 minId: minMsgId,
               })
               [Symbol.asyncIterator]()
-
             ;({ value: message, done } = await messageIterator.next())
           } else {
             throw error
@@ -225,6 +224,12 @@ export const run = async (
         }
 
         if (done) {
+          if (messages.length === 0) {
+            throw new Error(
+              `No messages found for ${dialogEntity.name} in the selected time period.`
+            )
+          }
+
           messageIterator = null
           await options?.onDialogRetrieved?.(BigInt(dialogEntity.id.toString()))
           break

--- a/app/providers/telegram.tsx
+++ b/app/providers/telegram.tsx
@@ -23,8 +23,6 @@ import { useGlobal } from '@/zustand/global'
 import { DialogInfo } from '@/api'
 import { fromResult, getErrorMessage } from '@/lib/errorhandling'
 import { useError } from './error'
-import TelegramAuth from '@/components/telegram-auth'
-import LogoSplash from '@/components/svgs/logo-splash'
 
 export interface ContextState {
   launchParams: LaunchParams
@@ -32,6 +30,7 @@ export interface ContextState {
   dialogs: DialogInfo[]
   loadingDialogs: boolean
   isTgAuthorized: boolean
+  isValidating: boolean
 }
 
 export interface ContextActions {
@@ -50,6 +49,7 @@ export const ContextDefaultValue: ContextValue = [
     dialogs: [],
     loadingDialogs: false,
     isTgAuthorized: false,
+    isValidating: true,
   },
   {
     getMe: () => Promise.reject(new Error('provider not setup')),
@@ -180,22 +180,21 @@ export const Provider = ({ children }: PropsWithChildren): ReactNode => {
     }
   }, [])
 
-  if (isValidating) {
-    return (
-      <div className="h-screen flex justify-center items-center bg-primary">
-        <LogoSplash />
-      </div>
-    )
-  }
-
   return (
     <Context.Provider
       value={[
-        { user, launchParams, dialogs, loadingDialogs, isTgAuthorized },
+        {
+          user,
+          launchParams,
+          dialogs,
+          loadingDialogs,
+          isTgAuthorized,
+          isValidating,
+        },
         { getMe, loadMoreDialogs, logout, setIsTgAuthorized },
       ]}
     >
-      {isTgAuthorized ? children : <TelegramAuth />}
+      {children}
     </Context.Provider>
   )
 }

--- a/app/providers/telegram.tsx
+++ b/app/providers/telegram.tsx
@@ -23,18 +23,22 @@ import { useGlobal } from '@/zustand/global'
 import { DialogInfo } from '@/api'
 import { fromResult, getErrorMessage } from '@/lib/errorhandling'
 import { useError } from './error'
+import TelegramAuth from '@/components/telegram-auth'
+import LogoSplash from '@/components/svgs/logo-splash'
 
 export interface ContextState {
   launchParams: LaunchParams
   user?: User
   dialogs: DialogInfo[]
   loadingDialogs: boolean
+  isTgAuthorized: boolean
 }
 
 export interface ContextActions {
   getMe: () => Promise<string | undefined>
   loadMoreDialogs: () => Promise<void>
   logout: () => Promise<void>
+  setIsTgAuthorized: (isTgAuthorized: boolean) => void
 }
 
 export type ContextValue = [state: ContextState, actions: ContextActions]
@@ -45,11 +49,15 @@ export const ContextDefaultValue: ContextValue = [
     user: undefined,
     dialogs: [],
     loadingDialogs: false,
+    isTgAuthorized: false,
   },
   {
     getMe: () => Promise.reject(new Error('provider not setup')),
     loadMoreDialogs: () => Promise.reject(new Error('provider not setup')),
     logout: () => Promise.reject(new Error('provider not setup')),
+    setIsTgAuthorized: () => {
+      throw new Error('provider not setup')
+    },
   },
 ]
 
@@ -60,9 +68,14 @@ export const Context = createContext<ContextValue>(ContextDefaultValue)
  * the context.
  */
 export const Provider = ({ children }: PropsWithChildren): ReactNode => {
-  const { tgSessionString } = useGlobal()
+  const { tgSessionString, setTgSessionString } = useGlobal()
+  const [isTgAuthorized, setIsTgAuthorized] = useState(false)
+  const [isValidating, setIsValidating] = useState(true)
+  const { setError } = useError()
+
   const user = useSignal(initData.user)
   const launchParams = useLaunchParams()
+
   const [dialogs, setDialogs] = useState<DialogInfo[]>([])
   const [offsetParams, setOffsetParams] = useState<{
     limit: number
@@ -72,10 +85,46 @@ export const Provider = ({ children }: PropsWithChildren): ReactNode => {
   }>({ limit: 20 })
   const [hasMore, setHasMore] = useState(true)
   const [loadingDialogs, setLoadingDialogs] = useState(false)
-  const { setError } = useError()
+
+  useEffect(() => {
+    const validateSession = async () => {
+      if (!tgSessionString) {
+        setIsValidating(false)
+        return
+      }
+      try {
+        setIsValidating(true)
+        fromResult(await getMeRequest(tgSessionString))
+        console.log('Session is valid, user is authorized')
+        setIsTgAuthorized(true)
+      } catch (err) {
+        console.log('Failed session token validation: ', err)
+
+        const errorMsg = getErrorMessage(err)
+        if (errorMsg.includes('client authorization failed')) {
+          console.log('Session validation failed, clearing session')
+          setTgSessionString('')
+          setIsTgAuthorized(false)
+        }
+      } finally {
+        setIsValidating(false)
+      }
+    }
+
+    validateSession()
+  }, [])
+
+  useEffect(() => {
+    if (!isTgAuthorized || !tgSessionString) return
+    setDialogs([])
+    setOffsetParams({ limit: 20 })
+    setHasMore(true)
+    loadMoreDialogs()
+  }, [tgSessionString])
 
   const logout = useCallback(async () => {
     try {
+      setIsTgAuthorized(false)
       if (!tgSessionString) return
       await logoutTelegram(tgSessionString)
     } catch (err) {
@@ -120,14 +169,6 @@ export const Provider = ({ children }: PropsWithChildren): ReactNode => {
     }
   }, [tgSessionString, hasMore, loadingDialogs, offsetParams, listDialogs])
 
-  useEffect(() => {
-    if (!tgSessionString) return
-    setDialogs([])
-    setOffsetParams({ limit: 20 })
-    setHasMore(true)
-    loadMoreDialogs()
-  }, [tgSessionString])
-
   const getMe = useCallback(async () => {
     if (!tgSessionString) return undefined
     try {
@@ -139,14 +180,22 @@ export const Provider = ({ children }: PropsWithChildren): ReactNode => {
     }
   }, [])
 
+  if (isValidating) {
+    return (
+      <div className="h-screen flex justify-center items-center bg-primary">
+        <LogoSplash />
+      </div>
+    )
+  }
+
   return (
     <Context.Provider
       value={[
-        { user, launchParams, dialogs, loadingDialogs },
-        { getMe, loadMoreDialogs, logout },
+        { user, launchParams, dialogs, loadingDialogs, isTgAuthorized },
+        { getMe, loadMoreDialogs, logout, setIsTgAuthorized },
       ]}
     >
-      {children}
+      {isTgAuthorized ? children : <TelegramAuth />}
     </Context.Provider>
   )
 }

--- a/app/zustand/global.ts
+++ b/app/zustand/global.ts
@@ -50,7 +50,6 @@ const saveSessionToString = (session?: Session | string) => {
 interface GlobalState {
   isFirstLogin: boolean
   isOnboarded: boolean
-  isTgAuthorized: boolean
   isStorachaAuthorized: boolean
   user: User | null
   phoneNumber: string
@@ -59,7 +58,6 @@ interface GlobalState {
 
   setIsFirstLogin: (isFirstLogin: boolean) => void
   setIsOnboarded: (isOnboarded: boolean) => void
-  setIsTgAuthorized: (isTgAuthorized: boolean) => void
   setIsStorachaAuthorized: (isStorachaAuthorized: boolean) => void
   setUser: (user: User) => void
   setPhoneNumber: (phone: string) => void
@@ -72,7 +70,6 @@ export const useGlobal = create<GlobalState>()(
     (set) => ({
       isFirstLogin: true,
       isOnboarded: false,
-      isTgAuthorized: false,
       isStorachaAuthorized: false,
       user: null,
       phoneNumber: '',
@@ -80,7 +77,6 @@ export const useGlobal = create<GlobalState>()(
       tgSessionString: '',
       setIsFirstLogin: (isFirstLogin) => set({ isFirstLogin }),
       setIsOnboarded: (isOnboarded) => set({ isOnboarded }),
-      setIsTgAuthorized: (isTgAuthorized) => set({ isTgAuthorized }),
       setIsStorachaAuthorized: (isStorachaAuthorized) =>
         set({ isStorachaAuthorized }),
       setUser: (user) => set({ user }),


### PR DESCRIPTION
This PR addresses two issues:

### 1. Empty Dialog Backup Handling
When backing up a chat with no messages in the selected time period, the backup would fail silently and users would see an empty visualization page without understanding why.

**Solution:** Added proper error handling to throw an error when no messages are found for a dialog in the selected period. 

**Future Consideration:** An alternative approach would be to skip empty dialogs and continue with the backup process, since there could be more dialogs to backup. We can evaluate this trade-off for now and improve it later.

### 2. Session Invalidation Recovery (Fixes #149)
When users deleted their Telegram session externally (via the Telegram app) and returned to the mini app, they encountered multiple errors instead of being redirected to re-authenticate.

**Solution:**
- Moved `isTgAuthorized` state from persistent global storage to local provider state to prevent stale authorization data
- Added session validation on app load in `TelegramProvider`
- Implemented proper error handling that only clears sessions on specific authorization failures