### PR TITLE
Feat: Fix bug and improve sign in flow

### DIFF
--- a/app/components/telegram-auth.tsx
+++ b/app/components/telegram-auth.tsx
@@ -63,6 +63,7 @@ function OTPForm({
   onSubmit,
   onCodeChange,
   onResend,
+  onBack,
   code,
   loading,
   error,
@@ -70,6 +71,7 @@ function OTPForm({
   onSubmit: () => unknown
   onCodeChange: (code: string) => unknown
   onResend: () => unknown
+  onBack: () => unknown
   code: string
   loading: boolean
   error?: Error
@@ -113,7 +115,16 @@ function OTPForm({
           Hurry... enter the pin you received on your Telegram.
         </p>
       </div>
-      <div className="flex justify-center items-center">
+      <div className="flex flex-col justify-center items-center gap-3">
+        <Button
+          type="button"
+          variant="outline"
+          className="w-full"
+          onClick={onBack}
+          disabled={loading}
+        >
+          Back
+        </Button>
         <Button type="submit" className="w-full" disabled={disabled}>
           {loading ? 'Loading...' : 'Submit OTP'}
         </Button>
@@ -359,6 +370,11 @@ export default function TelegramAuth() {
         }}
         onSubmit={handleCodeSubmit}
         onResend={handleResend}
+        onBack={() => {
+          setCodeHash('')
+          setError(undefined)
+          setCode('')
+        }}
         loading={loading}
         error={error}
       />

--- a/app/components/telegram-auth.tsx
+++ b/app/components/telegram-auth.tsx
@@ -219,7 +219,12 @@ export default function TelegramAuth() {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {
       console.error('requesting OTP:', err)
-      setError(err)
+      const errorMsg = getErrorMessage(error)
+      if (errorMsg.includes('PHONE_NUMBER_INVALID')) {
+        setError(new Error('Your phone number is incorrect. Please try again.'))
+      } else {
+        setError(err)
+      }
     } finally {
       setLoading(false)
     }

--- a/app/components/telegram-auth.tsx
+++ b/app/components/telegram-auth.tsx
@@ -273,6 +273,11 @@ export default function TelegramAuth() {
         await getSRP()
         set2FARequired(true)
         return
+      } else if (errorMsg.includes('PHONE_CODE_INVALID')) {
+        setError(
+          new Error('The code you entered is incorrect. Please try again.')
+        )
+        return
       }
       console.error('signing in:', err)
       setError(err)

--- a/app/components/telegram-auth.tsx
+++ b/app/components/telegram-auth.tsx
@@ -230,7 +230,7 @@ export default function TelegramAuth() {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {
       console.error('requesting OTP:', err)
-      const errorMsg = getErrorMessage(error)
+      const errorMsg = getErrorMessage(err)
       if (errorMsg.includes('PHONE_NUMBER_INVALID')) {
         setError(new Error('Your phone number is incorrect. Please try again.'))
       } else {
@@ -279,7 +279,8 @@ export default function TelegramAuth() {
       logTelegramLoginSuccess()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {
-      const errorMsg = getErrorMessage(error)
+      console.log('signing in:', err)
+      const errorMsg = getErrorMessage(err)
       if (errorMsg.includes('PASSWORD_HASH_INVALID')) {
         await getSRP()
         set2FARequired(true)
@@ -333,7 +334,7 @@ export default function TelegramAuth() {
     } catch (err: any) {
       console.error('checking password:', err)
       await getSRP()
-      const errorMsg = getErrorMessage(error)
+      const errorMsg = getErrorMessage(err)
       if (errorMsg.includes('PASSWORD_HASH_INVALID')) {
         setError(new Error('Your password was incorrect. Please try again.'))
       } else {


### PR DESCRIPTION
- handle proper error message (case invalid phone number and code)
<img width="402" alt="Screenshot 2568-06-27 at 17 35 33" src="https://github.com/user-attachments/assets/4f063c98-0b0f-4366-b919-a27891772016" />

<img width="397" alt="Screenshot 2568-06-27 at 17 39 09" src="https://github.com/user-attachments/assets/fef92f0a-c650-4f2b-ae6c-dd0bb49fcd1a" />

- add back button (if wrong number is input)
<img width="404" alt="Screenshot 2568-06-27 at 17 59 54" src="https://github.com/user-attachments/assets/5134c4c3-cd27-4985-9b3c-26b55e821a8f" />

- fix bug wrong typo (app/providers/telegram.tsx)
declare `err` but extract error from `error`
<img width="313" alt="Screenshot 2568-06-27 at 18 01 34" src="https://github.com/user-attachments/assets/1cc7600e-3623-4cfc-9c1c-31f3f278e2e2" />
