### PR TITLE
Feat: support message reaction

### DIFF
--- a/app/api.ts
+++ b/app/api.ts
@@ -304,7 +304,10 @@ export interface MessageData {
   /** The string text of the message. */
   message: string
   media?: MessageMedia
+  /** Message reactions if any. */
+  reactions?: MessageReactionsData
 }
+
 export interface ServiceMessageData {
   id: MessageID
   type: 'service'
@@ -2142,4 +2145,68 @@ export interface Ranking {
   rank: number
   percentile: number
   points: number
+}
+
+// Reaction-related types
+
+/** A single reaction (emoji or custom emoji sticker) */
+export type ReactionData =
+  | EmojiReactionData
+  | CustomEmojiReactionData
+  | UnknownReactionData
+
+export interface EmojiReactionData {
+  type: 'emoji'
+  /** The emoji character(s) */
+  emoticon: string
+}
+
+export interface CustomEmojiReactionData {
+  type: 'custom-emoji'
+  /** The custom emoji document ID */
+  documentId: ToString<bigint>
+}
+
+export interface UnknownReactionData {
+  type: 'unknown'
+}
+
+/** Aggregated count of a specific reaction */
+export interface ReactionCountData {
+  /** The reaction */
+  reaction: ReactionData
+  /** Number of users who reacted with this reaction */
+  count: number
+  /** Order if chosen by current user */
+  chosenOrder?: number
+}
+
+/** Individual user reaction */
+export interface MessagePeerReactionData {
+  /** Whether this is a "big" reaction */
+  big?: boolean
+  /** Whether this reaction is unread */
+  unread?: boolean
+  /** Whether this is the current user's reaction */
+  my?: boolean
+  /** ID of the user who reacted */
+  peerId: ToString<EntityID>
+  /** When the reaction was added */
+  date: number
+  /** The reaction */
+  reaction: ReactionData
+}
+
+/** Message reactions container */
+export interface MessageReactionsData {
+  /** Whether this is minimal reaction info */
+  min?: boolean
+  /** Whether the reaction list can be viewed */
+  canSeeList?: boolean
+  /** Whether reactions are displayed as tags */
+  reactionsAsTags?: boolean
+  /** Aggregated reaction counts */
+  results: ReactionCountData[]
+  /** Recent individual reactions */
+  recentReactions?: MessagePeerReactionData[]
 }

--- a/app/lib/server/runner.ts
+++ b/app/lib/server/runner.ts
@@ -41,6 +41,10 @@ import {
   WallPaperData,
   WallPaperSettingsData,
   MediaData,
+  ReactionData,
+  ReactionCountData,
+  MessagePeerReactionData,
+  MessageReactionsData,
 } from '@/api'
 import * as Type from '@/api'
 import { Api, TelegramClient } from 'telegram'
@@ -389,6 +393,14 @@ const toMessageData = (
 
     if (mediaRoot) {
       messageData['media'].content = mediaRoot
+    }
+  }
+
+  // Extract reactions if present
+  if (message.reactions) {
+    const reactions = toMessageReactionsData(message.reactions)
+    if (reactions) {
+      messageData.reactions = reactions
     }
   }
 
@@ -1687,6 +1699,64 @@ const toExtendedMediaData = withCleanUndef(
           type: 'unknown',
         } as Type.ExtendedMediaUnknownData
       }
+    }
+  }
+)
+
+const toReactionData = withCleanUndef(
+  (reaction: Api.TypeReaction): ReactionData => {
+    switch (reaction.className) {
+      case 'ReactionEmoji':
+        return {
+          type: 'emoji',
+          emoticon: reaction.emoticon,
+        }
+      case 'ReactionCustomEmoji':
+        return {
+          type: 'custom-emoji',
+          documentId: String(reaction.documentId),
+        }
+      default:
+        return {
+          type: 'unknown',
+        }
+    }
+  }
+)
+
+const toReactionCountData = withCleanUndef(
+  (reactionCount: Api.ReactionCount): ReactionCountData => {
+    return {
+      reaction: toReactionData(reactionCount.reaction),
+      count: reactionCount.count,
+      chosenOrder: reactionCount.chosenOrder,
+    }
+  }
+)
+
+const toMessagePeerReactionData = withCleanUndef(
+  (peerReaction: Api.MessagePeerReaction): MessagePeerReactionData => {
+    return {
+      big: peerReaction.big,
+      unread: peerReaction.unread,
+      my: peerReaction.my,
+      peerId: toPeerID(peerReaction.peerId),
+      date: peerReaction.date,
+      reaction: toReactionData(peerReaction.reaction),
+    }
+  }
+)
+
+const toMessageReactionsData = withCleanUndef(
+  (reactions: Api.MessageReactions): MessageReactionsData => {
+    return {
+      min: reactions.min,
+      canSeeList: reactions.canSeeList,
+      reactionsAsTags: reactions.reactionsAsTags,
+      results: reactions.results.map((r) => toReactionCountData(r)),
+      recentReactions: reactions.recentReactions?.map((r) =>
+        toMessagePeerReactionData(r)
+      ),
     }
   }
 )


### PR DESCRIPTION
solved #127 

ref: https://core.telegram.org/api/reactions

changed:
- [x] Update the `MessageData` type in `api.ts` to include a reactions property.
- [x] Update `runner.ts `to extract and store reactions from Telegram data when backing up messages.
- [x] Update `app/dialog/[id]/backup/[cid]/page.tsx` to display reactions for each message in the backup view.
- [x] support emoji on both message and media

<img width="398" alt="Screenshot 2568-06-28 at 18 31 06" src="https://github.com/user-attachments/assets/776a8bb0-e6b0-40a5-9fdf-d127f884abb0" />

<img width="387" alt="Screenshot 2568-06-28 at 18 46 22" src="https://github.com/user-attachments/assets/8e40375c-e4d8-4ef6-bbe0-9ab19d5ff87a" />


