### PR TITLE
fix: improve visualization to unsupported media

### DIFF
--- a/app/components/backup/dialog-item.tsx
+++ b/app/components/backup/dialog-item.tsx
@@ -12,7 +12,9 @@ export const DialogItem = ({ dialog, latestBackup }: DialogItemProps) => {
   const { name, initials, photo } = dialog
   const thumbSrc = getThumbSrc(photo?.strippedThumb)
   const { formatDateTime } = useUserLocale()
-  const latestBackupDate = formatDateTime(Number(latestBackup?.[1]))
+  const latestBackupDate = latestBackup
+    ? formatDateTime(Number(latestBackup[1]))
+    : undefined
 
   return (
     <div className="flex gap-4 items-center w-full">

--- a/app/components/ui/media.tsx
+++ b/app/components/ui/media.tsx
@@ -123,6 +123,14 @@ export const Media: React.FC<MediaProps> = ({ mediaUrl, metadata, time }) => {
       }
       break
     }
+    case 'unsupported': {
+      mediaContent = (
+        <Bubble>
+          <UnsupportedMedia />
+        </Bubble>
+      )
+      break
+    }
     default: {
       console.log(JSON.stringify(metadata))
       mediaContent = (
@@ -156,6 +164,14 @@ const PlaceholderBubble: React.FC<{ label?: string }> = ({ label }) => (
     {label ?? <p className="px-4">{label}</p>}
   </div>
 )
+
+const UnsupportedMedia: React.FC = () => {
+  return (
+    <div className="text-sm italic text-muted-foreground text-center">
+      ⚠️ This media type isn&#39;t supported by your Telegram app.
+    </div>
+  )
+}
 
 const ImageMedia: React.FC<{ mediaUrl?: string }> = ({ mediaUrl }) => {
   if (!mediaUrl) return <PlaceholderBubble label="no image" />


### PR DESCRIPTION
While debugging #160 , I found out this is actually a valid media type supported by Telegram, `MessageMediaUnsupported`, which, according to the [docs](https://core.telegram.org/constructor/messageMediaUnsupported), means: “The current version of the client does not support this media type.”

Given that, we have two options:

1. Skip it entirely and not show anything.
2. Display a message letting the user know that the media type isn’t supported.

This PR goes with the second option.

![image](https://github.com/user-attachments/assets/9ae6bc63-8567-41f1-977a-83439efa8db8)


