### PR TITLE
fix: skip unsupported media and fix missing user info header

### DIFF
--- a/app/components/ui/media.tsx
+++ b/app/components/ui/media.tsx
@@ -124,11 +124,7 @@ export const Media: React.FC<MediaProps> = ({ mediaUrl, metadata, time }) => {
       break
     }
     case 'unsupported': {
-      mediaContent = (
-        <Bubble>
-          <UnsupportedMedia />
-        </Bubble>
-      )
+      // skipping unsupported media types visualization
       break
     }
     default: {
@@ -164,14 +160,6 @@ const PlaceholderBubble: React.FC<{ label?: string }> = ({ label }) => (
     {label ?? <p className="px-4">{label}</p>}
   </div>
 )
-
-const UnsupportedMedia: React.FC = () => {
-  return (
-    <div className="text-sm italic text-muted-foreground text-center">
-      ⚠️ This media type isn&#39;t supported by your Telegram app.
-    </div>
-  )
-}
 
 const ImageMedia: React.FC<{ mediaUrl?: string }> = ({ mediaUrl }) => {
   if (!mediaUrl) return <PlaceholderBubble label="no image" />

--- a/app/lib/server/runner.ts
+++ b/app/lib/server/runner.ts
@@ -291,7 +291,7 @@ export const run = async (
           if (!mediaRoot) throw new Error('missing media root')
         }
 
-        messages.push(toMessageData(message, mediaRoot))
+        messages.push(toMessageData(message, fromID, mediaRoot))
         if (messages.length === maxMessages) {
           break
         }
@@ -354,10 +354,9 @@ const callWithDialogsSync = async <T>(
 
 const toMessageData = (
   message: Api.Message | Api.MessageService,
+  from: ToString<bigint>,
   mediaRoot?: Link<EncryptedTaggedByteView<Uint8Array>>
 ): MessageData | ServiceMessageData => {
-  const from = message.fromId && toPeerID(message.fromId)
-
   if (message.className === 'MessageService') {
     const action = toActionData(message.action)
     if (!action) throw new Error('missing service message action')


### PR DESCRIPTION

- Skip unsupported media messages: filter out messages with `MessageMediaUnsupported`
- Fix missing user info in chats: restore avatar and name display for participants in two-person conversations
- Fix infinite scroll loop: prevent useEffect dependency issues that caused continuous message loading