### PR TITLE
fix(backup): display service messages in chat view

### DIFF
--- a/app/app/dialog/[id]/backup/[cid]/page.tsx
+++ b/app/app/dialog/[id]/backup/[cid]/page.tsx
@@ -122,6 +122,271 @@ const ServiceMessage: React.FC<{ text: string }> = ({ text }) => {
   )
 }
 
+const formatServiceMessage = (
+  msg: ServiceMessageData,
+  participants: Record<string, EntityData>
+): string => {
+  const { action, from } = msg
+
+  const getUserName = (userId?: string) =>
+    userId ? (participants[userId]?.name ?? 'A user') : 'A user'
+
+  switch (action.type) {
+    case 'chat-create':
+      return `Chat was created with title "${action.title}"`
+    case 'chat-edit-title':
+      return `Group title was changed to "${action.title}"`
+    case 'chat-edit-photo':
+      return `${getUserName(from)} updated the group photo`
+    case 'chat-delete-photo':
+      return `${getUserName(from)} removed the group photo`
+    case 'chat-add-user':
+      const addedUsers = action.users
+        .map((userId) => getUserName(userId))
+        .join(', ')
+      return `${addedUsers} joined the group`
+    case 'chat-delete-user':
+      return `${getUserName(action.user)} was removed from the group`
+    case 'chat-joined-by-link':
+      return `${getUserName(from)} joined via an invite link`
+    case 'chat-joined-by-request':
+      return `${getUserName(from)} joined the chat by request`
+    case 'pin-message':
+      return `${getUserName(from)} pinned a message`
+    case 'screenshot-taken':
+      return `${getUserName(from)} took a screenshot`
+    case 'history-clear':
+      return `The chat history was cleared`
+    case 'channel-create':
+      return `Channel "${action.title}" was created.`
+    case 'boost-apply':
+      return `${action.boosts} boost(s) applied.`
+    case 'bot-allowed':
+      const botDetails = []
+      if (action.attachMenu) botDetails.push('attach menu enabled')
+      if (action.fromRequest) botDetails.push('allowed via request')
+      else botDetails.push('allowed')
+      if (action.domain) botDetails.push(`domain: ${action.domain}`)
+      if (action.app?.type === 'default') {
+        botDetails.push(`app: ${action.app.title}`)
+      }
+      return `Bot ${botDetails.join(', ')}.`
+    case 'channel-migrate-from':
+      return `This is a channel migrated from chat "${action.title}" (ID ${action.chat}).`
+    case 'chat-migrate-to':
+      return `This group was migrated to the channel with ID ${action.channel}.`
+    case 'contact-sign-up':
+      return `A contact in this chat signed up.`
+    case 'custom-action':
+      return action.message
+    case 'game-score':
+      return `Game score updated: game ${action.game}, score ${action.score}.`
+    case 'geo-proximity-reached':
+      return `Geo‑proximity reached between ${action.from} and ${action.to} (${action.distance}m apart).`
+    case 'gift-code': {
+      const parts: string[] = []
+      parts.push(`Gift code ${action.slug} for ${action.months} month(s)`)
+      if (action.viaGiveaway) {
+        parts.push(`via giveaway`)
+      }
+      parts.push(action.unclaimed ? `unclaimed` : `claimed`)
+      if (action.amount && action.currency) {
+        parts.push(`${action.amount} ${action.currency}`)
+      }
+      if (action.cryptoAmount && action.cryptoCurrency) {
+        parts.push(`plus ${action.cryptoAmount} ${action.cryptoCurrency}`)
+      }
+      if (action.message) {
+        parts.push(`message: "${action.message.text}"`)
+      }
+      return parts.join(', ') + '.'
+    }
+    case 'gift-premium': {
+      const parts: string[] = [
+        `${action.amount} ${action.currency} premium gift for ${action.months} month(s)`,
+      ]
+      if (action.cryptoCurrency && action.cryptoAmount) {
+        parts.push(
+          `plus ${action.cryptoAmount} ${action.cryptoCurrency} in crypto`
+        )
+      }
+      if (action.message) {
+        parts.push(`message: "${action.message.text}"`)
+      }
+      return parts.join('; ') + '.'
+    }
+    case 'gift-stars':
+      return `${action.amount} ${action.currency} stars gifted (total stars: ${action.stars}).`
+    case 'giveaway-launch':
+      return `Giveaway launched${action.stars ? ` for ${action.stars} stars` : ''}.`
+    case 'giveaway-results':
+      return `Giveaway ended: winners — ${action.winnersCount}, unclaimed — ${action.unclaimedCount}.`
+    case 'group-call':
+      return `Group call started (call ID ${action.call.id}). 
+                  Group call duration ${action?.duration}   `
+    case 'group-call-scheduled':
+      return `Group call scheduled for ${new Date(
+        action.scheduleDate * 1000
+      ).toLocaleString()}.`
+    case 'invite-to-group-call':
+      return `${action.users.join(', ')} invited to call ${action.call.id}.`
+    case 'payment-refunded':
+      return `Payment of ${action.totalAmount} ${action.currency} was refunded to ${action.peer}.`
+    case 'payment-sent':
+      return `Payment of ${action.totalAmount} ${action.currency} sent.`
+    case 'payment-sent-me':
+      const paymentDetails = []
+      paymentDetails.push(`${action.totalAmount} ${action.currency}`)
+      if (action.recurringInit)
+        paymentDetails.push('recurring payment initialized')
+      if (action.recurringUsed) paymentDetails.push('recurring payment used')
+      if (action.info?.name) paymentDetails.push(`from ${action.info.name}`)
+      if (action.shippingOptionId)
+        paymentDetails.push(`shipping: ${action.shippingOptionId}`)
+      return `Payment received: ${paymentDetails.join(', ')}.`
+    case 'phone-call': {
+      const parts: string[] = []
+      parts.push(action.video ? 'Video call' : 'Audio call')
+      parts.push(`ID ${action.call}`)
+      if (action.reason) {
+        const reason =
+          action.reason.charAt(0).toUpperCase() + action.reason.slice(1)
+        parts.push(`ended due to ${reason}`)
+      }
+      if (action.duration !== undefined) {
+        const mins = Math.floor(action.duration / 60)
+        const secs = action.duration % 60
+        parts.push(`duration ${mins}m ${secs}s`)
+      }
+
+      return parts.join(', ') + '.'
+    }
+    case 'prize-stars': {
+      const parts: string[] = []
+      parts.push(`Prize of ${action.stars} stars`)
+      parts.push(action.unclaimed ? 'unclaimed' : 'claimed')
+      parts.push(`boost from ${action.boostPeer}`)
+      parts.push(`giveaway message ID ${action.giveawayMsg}`)
+      parts.push(`txn ${action.transaction}`)
+      return parts.join(', ') + '.'
+    }
+    case 'requested-peer':
+      return `Requested peer(s): ${action.peers.join(', ')}.`
+    case 'requested-peer-sent-me': {
+      if (!action.peers.length) {
+        return `You received a peer request.`
+      }
+      const items = action.peers.map((peer) => {
+        switch (peer.type) {
+          case 'user': {
+            const name = [peer.firstName, peer.lastName]
+              .filter(Boolean)
+              .join(' ')
+            return name || peer.username || `user ${peer.id}`
+          }
+          case 'chat':
+            return peer.title ? `chat "${peer.title}"` : `chat ${peer.id}`
+          case 'channel':
+            return peer.title
+              ? `channel "${peer.title}"`
+              : peer.username
+                ? `@${peer.username}`
+                : `channel ${peer.id}`
+          default:
+            return `${peer.type}`
+        }
+      })
+      let who: string
+      if (items.length === 1) {
+        who = items[0]
+      } else if (items.length === 2) {
+        who = `${items[0]} and ${items[1]}`
+      } else {
+        who = `${items.slice(0, -1).join(', ')}, and ${items[items.length - 1]}`
+      }
+
+      return `You received a peer request for ${who}.`
+    }
+    case 'secure-values-sent': {
+      const typesList = action.types.join(', ')
+      return `Secure values sent: ${typesList}.`
+    }
+    case 'secure-values-sent-me': {
+      const summary = action.values.map((val) => {
+        let desc = val.type.replace('-', ' ')
+        if (val.plainData) {
+          if (val.plainData.type === 'phone') {
+            desc += ` (${val.plainData.phone})`
+          } else if (val.plainData.type === 'email') {
+            desc += ` (${val.plainData.email})`
+          }
+        } else {
+          const parts: string[] = []
+          if (val.data) parts.push('data blob')
+          if (val.frontSide) parts.push('front side photo')
+          if (val.reverseSide) parts.push('reverse side photo')
+          if (val.selfie) parts.push('selfie')
+          if (val.translation)
+            parts.push(`${val.translation.length} translation file(s)`)
+          if (val.files) parts.push(`${val.files.length} document file(s)`)
+          if (parts.length) {
+            desc += ` with ${parts.join(', ')}`
+          }
+        }
+        return desc
+      })
+
+      return `You received secure values: ${summary.join('; ')}.`
+    }
+    case 'set-chat-theme':
+      return `Chat theme set to "${action.emoticon}."`
+    case 'set-chat-wall-paper':
+      return `Chat wallpaper was changed.`
+    case 'set-messages-ttl':
+      return `Messages TTL set to ${action.period} seconds.`
+    case 'star-gift': {
+      const parts: string[] = []
+      parts.push(
+        `Star gift ID ${action.gift.id} for ${action.gift.stars} stars`
+      )
+      if (action.gift.limited) parts.push('limited edition')
+      if (action.gift.soldOut) parts.push('sold out')
+      if (action.gift.birthday) parts.push('birthday special')
+      if (
+        action.gift.availabilityRemains !== undefined &&
+        action.gift.availabilityTotal !== undefined
+      ) {
+        parts.push(
+          `availability ${action.gift.availabilityRemains}/${action.gift.availabilityTotal}`
+        )
+      }
+      if (action.nameHidden) parts.push('name hidden')
+      if (action.saved) parts.push('saved to collection')
+      if (action.converted)
+        parts.push(
+          `converted ${action.convertStars ?? action.gift.convertStars} stars`
+        )
+      if (action.message) {
+        parts.push(`message: "${action.message.text}"`)
+      }
+      return parts.join(', ') + '.'
+    }
+    case 'suggest-profile-photo':
+      return 'Profile photo suggestion received'
+    case 'topic-create':
+      return `Topic "${action.title}" created.`
+    case 'topic-edit':
+      return `Topic edited ${action.title ? action.title : ''}.`
+    case 'unknown':
+      return `An unknown action occurred.`
+    case 'web-view-data-sent':
+      return `Web‑view data sent: ${action.text}.`
+    case 'web-view-data-sent-me':
+      return `You sent web‑view data: ${action.text}.`
+  }
+}
+
+
 const UserInfo: React.FC<{ thumbSrc: string; userName: string }> = ({
   thumbSrc,
   userName,
@@ -144,8 +409,17 @@ function BackupDialog({
   mediaMap,
   isLoading,
   participants,
+  setParticipants,
+  getEntity,
   onScrollBottom,
-}: BackupDialogProps) {
+}: BackupDialogProps & {
+  setParticipants: React.Dispatch<
+    React.SetStateAction<Record<string, EntityData>>
+  >
+  getEntity: (
+    peerId: string
+  ) => Promise<{ id: string; name: string; photo?: Uint8Array } | undefined>
+}) {
   const chatContainerRef = useRef<HTMLDivElement>(null)
   const [isLoadingMore, setIsLoadingMore] = useState(false)
   let lastRenderedDate: string | null = null
@@ -157,6 +431,44 @@ function BackupDialog({
       decodeStrippedThumb(dialog.photo?.strippedThumb)
     )
   }
+
+  useEffect(() => {
+    const missing = new Set<string>()
+    for (const msg of messages) {
+      if (msg.type === 'service' && msg.action.type === 'chat-add-user') {
+        for (const uid of msg.action.users) {
+          if (!participants[uid]) missing.add(uid)
+        }
+      }
+    }
+    if (missing.size === 0) return
+
+    Promise.all(
+      Array.from(missing).map((uid) =>
+        getEntity(uid).then((data) => ({ uid, data }))
+      )
+    ).then((results) => {
+      const updates: Record<string, EntityData> = {}
+      for (const { uid, data } of results) {
+        if (data) {
+          updates[uid] = {
+            id: data.id,
+            name: data.name,
+            type: 'user',
+            photo: data.photo
+              ? {
+                  id: data.id,
+                  strippedThumb: data.photo,
+                }
+              : undefined,
+          }
+        }
+      }
+      if (Object.keys(updates).length) {
+        setParticipants((prev) => ({ ...prev, ...updates }))
+      }
+    })
+  }, [messages, participants, setParticipants, getEntity])
 
   useEffect(() => {
     const handleScroll = async () => {
@@ -195,23 +507,21 @@ function BackupDialog({
         name={dialog.name}
         type={dialog.type}
       />
-
-      {isLoading ? (
+     
+     {isLoading ? (
         <div className="flex flex-col items-center justify-center flex-1">
           <Loading text="Loading messages..." />
         </div>
       ) : (
-        <div
-          ref={chatContainerRef}
-          className="flex-1 overflow-y-auto px-4 py-6 space-y-4"
-          style={{ height: 'calc(100vh - 64px)' }} // Header height compensation
-        >
-          {messages
-            .filter((msg) => msg.type !== 'service')
-            .map((msg) => {
-              const date = formatDate(msg.date)
-              const showDate = lastRenderedDate !== date
-              if (showDate) lastRenderedDate = date
+      <div
+        ref={chatContainerRef}
+        className="flex-1 overflow-y-auto px-4 py-6 space-y-4"
+        style={{ height: 'calc(100vh - 64px)' }} // Ensure proper height
+      >
+        {messages.map((msg) => {
+            const date = formatDate(msg.date)
+            const showDate = lastRenderedDate !== date
+            if (showDate) lastRenderedDate = date
 
               const isOutgoing = msg.from === userId
               const sender = msg.from
@@ -222,69 +532,75 @@ function BackupDialog({
               lastSenderId = msg.from ?? null
 
               let thumbSrc = ''
-              if (msg.from && participants[msg.from].photo?.strippedThumb) {
-                thumbSrc = toJPGDataURL(
-                  decodeStrippedThumb(
-                    participants[msg.from].photo?.strippedThumb as Uint8Array
-                  )
+            if (msg.from && participants[msg.from]?.photo?.strippedThumb) {
+              thumbSrc = toJPGDataURL(
+                decodeStrippedThumb(
+                  participants[msg.from]?.photo?.strippedThumb as Uint8Array
+                )
+              )
+            }
+
+            let mediaUrl: string | undefined
+            if (msg.type === 'message' && msg.media?.content) {
+              const rawContent = mediaMap[msg.media.content.toString()]
+              const type =
+                msg.media.metadata.type === 'document'
+                  ? msg.media.metadata.document?.mimeType
+                  : ''
+              if (rawContent) {
+                mediaUrl = URL.createObjectURL(
+                  new Blob([rawContent], { type: type })
                 )
               }
+            }
 
-              let mediaUrl: string | undefined
-              if (msg.media?.content) {
-                const rawContent = mediaMap[msg.media.content.toString()]
-                const type =
-                  msg.media.metadata.type === 'document'
-                    ? msg.media.metadata.document?.mimeType
-                    : ''
-                if (rawContent) {
-                  mediaUrl = URL.createObjectURL(
-                    new Blob([rawContent], { type })
-                  )
-                }
-              }
-
-              return (
-                <Fragment key={msg.id}>
-                  {showDate && <ServiceMessage text={date} />}
-                  {msg.type === 'message' && (
-                    <div
-                      className={`flex ${
-                        isOutgoing ? 'justify-end' : 'justify-start'
-                      }`}
-                    >
-                      <div className="flex flex-col max-w-[75%]">
-                        {showSenderHeader && (
-                          <UserInfo thumbSrc={thumbSrc} userName={sender} />
-                        )}
-                        {msg.media ? (
-                          <MessageWithMedia
-                            isOutgoing={isOutgoing}
-                            date={msg.date}
-                            message={msg.message}
-                            metadata={msg.media.metadata}
-                            mediaUrl={mediaUrl}
-                          />
-                        ) : (
-                          <Message
-                            isOutgoing={isOutgoing}
-                            date={msg.date}
-                            message={msg.message}
-                          />
-                        )}
-                      </div>
+            return (
+              <Fragment key={msg.id}>
+                {showDate && <ServiceMessage text={date} />}
+                {/* { msg.type === 'service' && <ServiceMessage text={msg.action.description} /> } // TODO: would be nice to have a description for each action */}
+                {msg.type === 'service' ? (
+                <div className="flex flex-col items-center space-y-1">
+                  <ServiceMessage
+                    text={formatServiceMessage(msg, participants)}
+                  />
+                </div>
+              ) : (
+                  <div
+                    className={`flex ${
+                      isOutgoing ? 'justify-end' : 'justify-start'
+                    }`}
+                  >
+                    <div className="flex flex-col max-w-[75%]">
+                      {showSenderHeader && (
+                        <UserInfo thumbSrc={thumbSrc} userName={sender} />
+                      )}
+                      {msg.media ? (
+                        <MessageWithMedia
+                          isOutgoing={isOutgoing}
+                          date={msg.date}
+                          message={msg.message}
+                          metadata={msg.media.metadata}
+                          mediaUrl={mediaUrl}
+                        />
+                      ) : (
+                        <Message
+                          isOutgoing={isOutgoing}
+                          date={msg.date}
+                          message={msg.message}
+                        />
+                      )}
                     </div>
-                  )}
-                </Fragment>
-              )
-            })}
-
-          {isLoadingMore && (
-            <div className="text-center py-4">
-              <Loading text="Loading more messages..." />
-            </div>
-          )}
-        </div>
+                  </div>
+                )}
+              </Fragment>
+            )
+          })}
+        {isLoadingMore && (
+          <div className="text-center py-4">
+            <Loading text="Loading more messages..." />
+          </div>
+        )}
+      </div>
       )}
     </div>
   )
@@ -292,7 +608,7 @@ function BackupDialog({
 
 export default function Page() {
   const router = useRouter()
-  const [{}, { getMe }] = useTelegram()
+  const [{}, { getMe, getEntity }] = useTelegram()
   const [
     { restoredBackup },
     { restoreBackup, fetchMoreMessages, resetBackup },
@@ -338,7 +654,15 @@ export default function Page() {
 
     fetchBackup()
   }, [backupCid, restoreBackup, getMe])
+  const [localParticipants, setLocalParticipants] = useState(
+    restoredBackup.item?.participants ?? {}
+  )
 
+  useEffect(() => {
+    if (restoredBackup.item) {
+      setLocalParticipants(restoredBackup.item.participants)
+    }
+  }, [restoredBackup.item])
   const handleFetchMoreMessages = async () => {
     if (
       restoredBackup.item?.hasMoreMessages &&
@@ -366,7 +690,9 @@ export default function Page() {
           dialog={restoredBackup.item.dialogData}
           messages={restoredBackup.item.messages}
           mediaMap={restoredBackup.item.mediaMap}
-          participants={restoredBackup.item.participants}
+          participants={localParticipants}
+          setParticipants={setLocalParticipants}
+          getEntity={getEntity}
           onScrollBottom={handleFetchMoreMessages}
         />
       ) : (

--- a/app/components/server.ts
+++ b/app/components/server.ts
@@ -243,3 +243,28 @@ export const getRanking = toResultFn(
     }
   )
 )
+
+export const getEntity = toResultFn(
+  withClient(async (client: TelegramClient, peerId: string) => {
+    const entity = await client.getEntity(bigInt(peerId))
+    const basic: Pick<DialogInfo, 'id' | 'name' | 'photo'> = {
+      id: entity.id.toString(),
+      name:
+        'firstName' in entity
+          ? [entity.firstName, entity.lastName].filter(Boolean).join(' ')
+          : 'title' in entity
+            ? entity.title
+            : '',
+      photo:
+        'photo' in entity &&
+        entity.photo?.className === 'UserProfilePhoto' &&
+        entity.photo.strippedThumb
+          ? {
+              id: entity.photo.photoId.toString(),
+              strippedThumb: new Uint8Array(entity.photo.strippedThumb),
+            }
+          : undefined,
+    }
+    return basic
+  })
+)


### PR DESCRIPTION
### Summary

This PR fixes issue #94 by making service messages (such as users joining, leaving, or group info changes) visible in the chat backup view. Previously, these events were backed up but not shown, resulting in incomplete chat histories.

### Details

- Removes the filter that previously hid service messages.
- Renders service messages inline with chat history using a distinct, centered style.
- Adds a `formatServiceMessage` helper to convert raw action data into readable text 
- Dynamically fetches user info for users referenced in service messages who are not already in the backup.
- Gracefully handles cases where user info cannot be fetched, displaying "A user" as needed.
- Skips rendering messages with unsupported media types.



### Screenshots

![Screenshot 2025-07-01 170103](https://github.com/user-attachments/assets/084797c0-83a3-4121-8e4c-fb3fafd72990)
----
![Screenshot 2025-07-01 170111](https://github.com/user-attachments/assets/94528dc2-3119-49c0-9728-42f2c2a2f819)

---




Fixes #94