### PR TITLE
fix: rename telegram session

### DIFF
--- a/app/components/telegram-auth.tsx
+++ b/app/components/telegram-auth.tsx
@@ -16,16 +16,10 @@ import { StringSession } from '@/vendor/telegram/sessions'
 import { TelegramClientParams } from '@/vendor/telegram/client/telegramBaseClient'
 import { getErrorMessage } from '@/lib/errorhandling'
 import { useAnalytics } from '@/lib/analytics'
+import { defaultClientParams } from '@/lib/server/constants'
 
 const apiId = parseInt(process.env.NEXT_PUBLIC_TELEGRAM_API_ID ?? '')
 const apiHash = process.env.NEXT_PUBLIC_TELEGRAM_API_HASH ?? ''
-const appVersion = process.env.version ?? '1.0.0'
-const defaultClientParams: TelegramClientParams = {
-  connectionRetries: 5,
-  deviceModel: 'Storacha',
-  systemVersion: 'Linux',
-  appVersion,
-}
 
 function CountDown({ onResend }: { onResend: () => unknown }) {
   const [count, setCount] = useState(59)

--- a/app/components/telegram-auth.tsx
+++ b/app/components/telegram-auth.tsx
@@ -210,7 +210,7 @@ export default function TelegramAuth() {
       new StringSession(tgSessionString),
       apiId,
       apiHash,
-      defaultClientParams
+      defaultClientParams as unknown as TelegramClientParams
     )
     setClient(newClient)
   }, [tgSessionString])

--- a/app/lib/backup/utils.ts
+++ b/app/lib/backup/utils.ts
@@ -79,6 +79,8 @@ export const buildDialogInputPeer = (dialogInfo: DialogInfo) => {
     return new Api.InputPeerUser({ userId: bigId, accessHash: bigHash })
   } else if (dialogInfo.type === 'channel') {
     return new Api.InputPeerChannel({ channelId: bigId, accessHash: bigHash })
+  } else if (dialogInfo.type === 'chat') {
+    return new Api.InputPeerChat({ chatId: bigId })
   }
 
   return undefined

--- a/app/lib/server/constants.ts
+++ b/app/lib/server/constants.ts
@@ -3,6 +3,7 @@ import { connect } from '@ucanto/client'
 import { CAR, HTTP } from '@ucanto/transport'
 import { ed25519 } from '@ucanto/principal'
 import type { Service } from '@storacha/client/types'
+import { TelegramClientParams } from 'telegram/client/telegramBaseClient'
 
 let cachedServerConstants: {
   SERVER_IDENTITY_PRIVATE_KEY: string
@@ -131,7 +132,7 @@ export const mRachaPointsPerByte = parseFloat(
   process.env.NEXT_PUBLIC_POINTS_PER_BYTE ?? die('NEXT_PUBLIC_POINTS_PER_BYTE')
 )
 
-const appVersion = process.env.version ?? '1.0.0'
+const appVersion = process.env.version ?? '0.0.0'
 export const defaultClientParams: TelegramClientParams = {
   connectionRetries: 5,
   deviceModel: 'Storacha',

--- a/app/lib/server/constants.ts
+++ b/app/lib/server/constants.ts
@@ -130,3 +130,11 @@ export const telegramAPIHash =
 export const mRachaPointsPerByte = parseFloat(
   process.env.NEXT_PUBLIC_POINTS_PER_BYTE ?? die('NEXT_PUBLIC_POINTS_PER_BYTE')
 )
+
+const appVersion = process.env.version ?? '1.0.0'
+export const defaultClientParams: TelegramClientParams = {
+  connectionRetries: 5,
+  deviceModel: 'Storacha',
+  systemVersion: 'Linux',
+  appVersion,
+}

--- a/app/lib/server/session.ts
+++ b/app/lib/server/session.ts
@@ -25,10 +25,6 @@ export async function getSession(): Promise<IronSession<TGSession>> {
 }
 
 export async function clearSession() {
-  const { SESSION_PASSWORD, SESSION_COOKIE_NAME } = getServerConstants()
-  const session = await getIronSession<TGSession>(await cookies(), {
-    password: SESSION_PASSWORD,
-    cookieName: SESSION_COOKIE_NAME,
-  })
-  session.destroy()
+  const session = await getSession()
+  await session.destroy()
 }

--- a/app/lib/server/telegram-manager.ts
+++ b/app/lib/server/telegram-manager.ts
@@ -1,6 +1,5 @@
 import { TelegramClient } from 'telegram'
 import { StringSession } from 'telegram/sessions'
-import { TelegramClientParams } from 'telegram/client/telegramBaseClient'
 import {
   telegramAPIID,
   telegramAPIHash,

--- a/app/lib/server/telegram-manager.ts
+++ b/app/lib/server/telegram-manager.ts
@@ -1,9 +1,11 @@
 import { TelegramClient } from 'telegram'
 import { StringSession } from 'telegram/sessions'
 import { TelegramClientParams } from 'telegram/client/telegramBaseClient'
-import { telegramAPIID, telegramAPIHash } from '@/lib/server/constants'
-
-const defaultClientParams: TelegramClientParams = { connectionRetries: 5 }
+import {
+  telegramAPIID,
+  telegramAPIHash,
+  defaultClientParams,
+} from '@/lib/server/constants'
 
 export const getTelegramClient = async (
   session: string


### PR DESCRIPTION
- fixes #150,  it wasn’t fully fixed because we instantiate the client in two places, but only one had the correct parameters.
- Fixes `buildDialogInputPeer`by adding a `InputPeerChat` type