### PR TITLE
fix: fetch high quality images for profile pictures in the list of chats

### DIFF
--- a/app/app/api/entity/[id]/image/route.ts
+++ b/app/app/api/entity/[id]/image/route.ts
@@ -1,0 +1,56 @@
+import { getHiResPhotoBlob } from '@/components/server'
+import { getBotToken } from '@/lib/server/constants'
+
+import { NextRequest } from 'next/server'
+
+export async function GET(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> }
+) {
+  console.log(`setting up notification stream for job updates`)
+  try {
+    const searchParams = request.nextUrl.searchParams
+    const session = searchParams.get('session')
+
+    if (!session) {
+      return new Response(
+        JSON.stringify({ error: 'Please specify a session to use' }),
+        {
+          headers: { 'Content-Type': 'application/json' },
+          status: 400,
+        }
+      )
+    }
+
+    const accessHash = searchParams.get('access')
+    const { id } = await params
+    const result = await getHiResPhotoBlob(session, id, accessHash ?? undefined)
+
+    if (result.ok) {
+      return new Response(result.ok, {
+        headers: {
+          'Access-Control-Allow-Origin': '*',
+          'Cache-Control': 'public, max-age=31536000, immutable',
+          'Content-Type': 'image/jpeg',
+
+          // this is a new-ish header that tells the cache to ignore query params - this is what
+          // we want since the images are uniquely identified by id
+          'No-Vary-Search': 'params',
+        },
+        status: 200,
+      })
+    } else {
+      console.error(result.error)
+      return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+        headers: { 'Content-Type': 'application/json' },
+        status: 500,
+      })
+    }
+  } catch (error) {
+    console.error('Server error:', error)
+    return new Response(JSON.stringify({ error: 'Internal Server Error' }), {
+      headers: { 'Content-Type': 'application/json' },
+      status: 500,
+    })
+  }
+}

--- a/app/components/backup/dialog-item.tsx
+++ b/app/components/backup/dialog-item.tsx
@@ -62,9 +62,7 @@ export const DialogItem = ({ dialog, latestBackup }: DialogItemProps) => {
         <AvatarFallback>{initials}</AvatarFallback>
       </Avatar>
       <div className="flex-auto">
-        <h1 className="font-semibold text-foreground/80">
-          {name} {id}
-        </h1>
+        <h1 className="font-semibold text-foreground/80">{name}</h1>
         <p className="text-sm text-foreground/60">
           Last Backup:{' '}
           {latestBackupDate ?? <span className="text-red-900">Never</span>}

--- a/app/components/backup/dialog-item.tsx
+++ b/app/components/backup/dialog-item.tsx
@@ -2,15 +2,54 @@ import { AbsolutePeriod, DialogInfo } from '@/api'
 import { Avatar, AvatarFallback, AvatarImage } from '@/components/ui/avatar'
 import { useUserLocale } from '@/hooks/useUserLocale'
 import { getThumbSrc } from '@/lib/backup/utils'
+import { useGlobal } from '@/zustand/global'
+import { useEffect, useState } from 'react'
 
 interface DialogItemProps {
   dialog: DialogInfo
   latestBackup?: AbsolutePeriod
 }
 
+// Try to fetch the high quality photo for the given entity.
+// If it works, the image will be cached and can be passed to an image src url.
+function useHighQualityProfilePhoto(
+  entityId: string,
+  accessHash?: string
+): string | undefined {
+  const [hqUrl, setHqUrl] = useState<string>()
+  const { tgSessionString } = useGlobal()
+  useEffect(
+    function () {
+      console.log('loading HQ for id ', entityId)
+      if (entityId) {
+        ;(async function () {
+          // session is required for this to work unless it's been cached
+          // but we keep it in a query param so that browsers with support for
+          // No-Vary-Search ignore it when considering whether to cache the image.
+          const query: { access?: string; session: string } = {
+            session: tgSessionString,
+          }
+          if (accessHash) query.access = accessHash
+          const queryString = new URLSearchParams(query).toString()
+          const url = `/api/entity/${encodeURIComponent(entityId)}/image${queryString ? `?${queryString}` : ''}`
+          const result = await fetch(url)
+          if (result.status === 200) {
+            setHqUrl(url)
+          }
+        })()
+      }
+    },
+    [entityId]
+  )
+  return hqUrl
+}
+
 export const DialogItem = ({ dialog, latestBackup }: DialogItemProps) => {
-  const { name, initials, photo } = dialog
-  const thumbSrc = getThumbSrc(photo?.strippedThumb)
+  const { id, name, initials, photo, dialogId, accessHash } = dialog
+  const lqThumbSrc = getThumbSrc(photo?.strippedThumb)
+  const hqThumbSrc =
+    dialogId && useHighQualityProfilePhoto(dialogId, accessHash)
+
   const { formatDateTime } = useUserLocale()
   const latestBackupDate = latestBackup
     ? formatDateTime(Number(latestBackup[1]))
@@ -19,11 +58,13 @@ export const DialogItem = ({ dialog, latestBackup }: DialogItemProps) => {
   return (
     <div className="flex gap-4 items-center w-full">
       <Avatar className="flex-none">
-        <AvatarImage src={thumbSrc} />
+        <AvatarImage src={hqThumbSrc || lqThumbSrc} />
         <AvatarFallback>{initials}</AvatarFallback>
       </Avatar>
       <div className="flex-auto">
-        <h1 className="font-semibold text-foreground/80">{name}</h1>
+        <h1 className="font-semibold text-foreground/80">
+          {name} {id}
+        </h1>
         <p className="text-sm text-foreground/60">
           Last Backup:{' '}
           {latestBackupDate ?? <span className="text-red-900">Never</span>}

--- a/app/components/server.ts
+++ b/app/components/server.ts
@@ -255,13 +255,11 @@ export const getHiResPhotoBlob = toResultFn(
       try {
         entity = await client.getEntity(id)
       } catch (e) {
-        // there seem to be a few entities that don't load properly using the code above
+        // there seem to be a few user entities that don't load properly using the code above
         // but do load if we construct the Peer manually, so do that as a fallback
         entity = new Api.InputPeerUser({
-          // @ts-expect-error TS thinks this shouldn't be a string, but the library is fine with it
-          userId: id,
-          // @ts-expect-error TS thinks this shouldn't be a string, but the library is fine with it
-          accessHash: accessHash ?? 0,
+          userId: bigInt(id),
+          accessHash: accessHash ? bigInt(accessHash) : bigInt(0),
         })
       }
       return await client.downloadProfilePhoto(entity)


### PR DESCRIPTION
It turns out the only way to get high quality images is to request them from the API. Furthermore, not all images are loadable using `client.getEntity` but it's difficult to determine which will work and which won't.

This PR introduces two things:

1. some client-side code to attempt to load the high quality version of an image using a new API endpoint in this app 
2. the new API endpoint itself, which tries to fetch the image a couple different ways and then sets cache headers that tell the browser to consider the image immutable

The net result here is that we'll (a) try pretty hard to load images from Telegram and then (b) aggressively cache successful results - taken alone (a) might be a cause for performance concern, but (b) should compensate pretty well for that.