### PR TITLE
feat: set app name to avoid showing pricing table in email

### DIFF
--- a/app/components/backup/connect.tsx
+++ b/app/components/backup/connect.tsx
@@ -1,4 +1,4 @@
-import { useW3 as useStoracha } from '@storacha/ui-react'
+import { AppName, useW3 as useStoracha } from '@storacha/ui-react'
 import { email as parseEmail } from '@storacha/did-mailto'
 import {
   Drawer,
@@ -169,7 +169,9 @@ export const StorachaConnect = ({
       setConnErr(undefined)
       setVerifying(true)
       logStorachaLoginStarted()
-      const account = await client.login(parseEmail(email))
+      const account = await client.login(parseEmail(email), {
+        appName: AppName.TGMiniapp,
+      })
       const plan = await account.plan.get()
 
       if (plan.ok?.product) {

--- a/app/package.json
+++ b/app/package.json
@@ -38,7 +38,7 @@
     "@storacha/client": "^1.4.0",
     "@storacha/did-mailto": "^1.0.2",
     "@storacha/ucn": "1.1.0-rc.4",
-    "@storacha/ui-react": "^2.7.8",
+    "@storacha/ui-react": "^2.7.13",
     "@storacha/upload-client": "^1.2.3",
     "@telegram-apps/init-data-node": "^2.0.7",
     "@telegram-apps/sdk-react": "^2.0.20",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,8 +87,8 @@ importers:
         specifier: 1.1.0-rc.4
         version: 1.1.0-rc.4
       '@storacha/ui-react':
-        specifier: ^2.7.8
-        version: 2.7.8(@types/react@18.3.1)(encoding@0.1.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
+        specifier: ^2.7.13
+        version: 2.7.13(@types/react@18.3.1)(encoding@0.1.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@storacha/upload-client':
         specifier: ^1.2.3
         version: 1.2.3(encoding@0.1.13)
@@ -187,7 +187,7 @@ importers:
         version: 2.5.5
       tailwindcss-animate:
         specifier: ^1.0.7
-        version: 1.0.7(tailwindcss@3.4.1(ts-node@10.9.1(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@20.0.0)(typescript@5.5.4)))
+        version: 1.0.7(tailwindcss@3.4.1(ts-node@9.1.1(typescript@5.5.4)))
       telegram:
         specifier: 2.26.8
         version: 2.26.8
@@ -236,7 +236,7 @@ importers:
         version: 3.5.3
       tailwindcss:
         specifier: ^3.4.1
-        version: 3.4.1(ts-node@10.9.1(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@20.0.0)(typescript@5.5.4))
+        version: 3.4.1(ts-node@9.1.1(typescript@5.5.4))
       typescript:
         specifier: 5.5.4
         version: 5.5.4
@@ -3107,6 +3107,9 @@ packages:
   '@storacha/access@1.2.2':
     resolution: {integrity: sha512-ezL1MmPX9XL7GTOF4ZKf3jZWVSkrDvtzlLrKJlEsQZRM9UFRVops6Uf/yeQioy1eAgFh0HUUixa88YyPek21BQ==}
 
+  '@storacha/access@1.3.0':
+    resolution: {integrity: sha512-DSfCgGuREvYsAJiESy2qOHR1PPHyh7KDfgjWc7s0cK3YZoBXQghajZwUbViaSj4R7waNPJNi8FMCQVcyxntMdQ==}
+
   '@storacha/blob-index@1.1.0':
     resolution: {integrity: sha512-f8+e7N6ww/YJ83Z4GeeGuQevVueRLg3StB0kv36ia/RkOWGBzqzoDQvXnxTY5rTJzcDT712pZdVcdHJX6jwbkg==}
     engines: {node: '>=16.15'}
@@ -3116,6 +3119,10 @@ packages:
 
   '@storacha/client@1.4.0':
     resolution: {integrity: sha512-APTALFekKg9FBHym7/B5jkqP8v/71C6ZToyWKqFdaWdoNZJM8ZNK/KNkB5tyMdboYxvfkXwHl9gSxEoW+wgSgA==}
+    engines: {node: '>=18'}
+
+  '@storacha/client@1.4.2':
+    resolution: {integrity: sha512-KZ9HvD3QEuNCuMFjKIy2tHg+6Ka52Zq2TpMqE7AZAJhriOqcoVOXDrXU53pzRpzntK1RKK5JPPodR/qOl/prfw==}
     engines: {node: '>=18'}
 
   '@storacha/did-mailto@1.0.2':
@@ -3132,16 +3139,19 @@ packages:
     resolution: {integrity: sha512-Zx9iX7Iq4pLmwnwPW61jtr+M04fZdM/hghxs6g/j7jYw9qIqJXQVh7k97wCCmStSyvliUlgN7d1QfwosjrxNTA==}
     hasBin: true
 
-  '@storacha/ui-core@2.4.67':
-    resolution: {integrity: sha512-XoDzsnm5KiCTK3AcjawSAIU07nr5vHr4dD5vwLl1akTnTBr3yzGPCqxZlRYcMjpfyd797KqnYm5Q705dU4fcXg==}
+  '@storacha/ui-core@2.4.72':
+    resolution: {integrity: sha512-EJdSAJPh6z718C9sKR94uJGNb+4oVuIcsvukyLuY6iBO8lA3eKii1S/SWQIi83JB8Mu3wWFVzn7Fd5cmnMypYg==}
 
-  '@storacha/ui-react@2.7.8':
-    resolution: {integrity: sha512-ejGjagoJZAtj6W2ta0v7aJgIXpCb/lcdp25PyD5kr7JUsukZV9cBalkFb1MwETyEeWPPaKXciN6apB1rKu0kSg==}
+  '@storacha/ui-react@2.7.13':
+    resolution: {integrity: sha512-Rid0k4kZA0oIG4csQcpG6QmtzNkNp3jlmDEr11h/pCdi9Y1R9/yn4uMD0i6ohsCtpyc5E9CHulh34TNikUqBqg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
 
   '@storacha/upload-client@1.2.3':
     resolution: {integrity: sha512-eVFAbXuLkoryhHvN9VMsmHR3nqUZfGTo22CodTKbLRlCCSEc6zpz+tpvjWYar+5/nwlQhRFWOBOJVTkb0KgRQA==}
+
+  '@storacha/upload-client@1.2.4':
+    resolution: {integrity: sha512-Qn8FWGsa0QKelemVOydNxGrEQtvahvQM1xaBGKl5F4v6sYGuABATSJY4PJEYpaNthTmuFkNlebYN/BFvIJ70Vg==}
 
   '@swc/core-darwin-arm64@1.11.29':
     resolution: {integrity: sha512-whsCX7URzbuS5aET58c75Dloby3Gtj/ITk2vc4WW6pSDQKSPDuONsIcZ7B2ng8oz0K6ttbi4p3H/PNPQLJ4maQ==}
@@ -11906,6 +11916,27 @@ snapshots:
       type-fest: 4.41.0
       uint8arrays: 5.1.0
 
+  '@storacha/access@1.3.0':
+    dependencies:
+      '@ipld/car': 5.4.2
+      '@ipld/dag-ucan': 3.4.5
+      '@scure/bip39': 1.6.0
+      '@storacha/capabilities': 1.7.0
+      '@storacha/did-mailto': 1.0.2
+      '@storacha/one-webcrypto': 1.0.1
+      '@ucanto/client': 9.0.1
+      '@ucanto/core': 10.4.0
+      '@ucanto/interface': 10.3.0
+      '@ucanto/principal': 9.0.2
+      '@ucanto/transport': 9.2.0
+      '@ucanto/validator': 9.1.0
+      bigint-mod-arith: 3.3.1
+      conf: 11.0.2
+      multiformats: 13.3.6
+      p-defer: 4.0.1
+      type-fest: 4.41.0
+      uint8arrays: 5.1.0
+
   '@storacha/blob-index@1.1.0':
     dependencies:
       '@ipld/dag-cbor': 9.2.2
@@ -11936,6 +11967,24 @@ snapshots:
       '@storacha/did-mailto': 1.0.2
       '@storacha/filecoin-client': 1.0.9
       '@storacha/upload-client': 1.2.3(encoding@0.1.13)
+      '@ucanto/client': 9.0.1
+      '@ucanto/core': 10.4.0
+      '@ucanto/interface': 10.3.0
+      '@ucanto/principal': 9.0.2
+      '@ucanto/transport': 9.2.0
+      environment: 1.1.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@storacha/client@1.4.2(encoding@0.1.13)':
+    dependencies:
+      '@ipld/dag-ucan': 3.4.5
+      '@storacha/access': 1.3.0
+      '@storacha/blob-index': 1.1.0
+      '@storacha/capabilities': 1.7.0
+      '@storacha/did-mailto': 1.0.2
+      '@storacha/filecoin-client': 1.0.9
+      '@storacha/upload-client': 1.2.4(encoding@0.1.13)
       '@ucanto/client': 9.0.1
       '@ucanto/core': 10.4.0
       '@ucanto/interface': 10.3.0
@@ -11977,11 +12026,11 @@ snapshots:
       p-retry: 5.1.2
       sade: 1.8.1
 
-  '@storacha/ui-core@2.4.67(encoding@0.1.13)':
+  '@storacha/ui-core@2.4.72(encoding@0.1.13)':
     dependencies:
       '@ipld/dag-ucan': 3.4.5
-      '@storacha/access': 1.2.2
-      '@storacha/client': 1.4.0(encoding@0.1.13)
+      '@storacha/access': 1.3.0
+      '@storacha/client': 1.4.2(encoding@0.1.13)
       '@storacha/did-mailto': 1.0.2
       '@ucanto/client': 9.0.1
       '@ucanto/interface': 10.3.0
@@ -11990,11 +12039,11 @@ snapshots:
     transitivePeerDependencies:
       - encoding
 
-  '@storacha/ui-react@2.7.8(@types/react@18.3.1)(encoding@0.1.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
+  '@storacha/ui-react@2.7.13(@types/react@18.3.1)(encoding@0.1.13)(react-dom@19.0.0(react@19.0.0))(react@19.0.0)':
     dependencies:
       '@ariakit/react': 0.3.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
       '@ariakit/react-core': 0.3.14(react-dom@19.0.0(react@19.0.0))(react@19.0.0)
-      '@storacha/ui-core': 2.4.67(encoding@0.1.13)
+      '@storacha/ui-core': 2.4.72(encoding@0.1.13)
       ariakit-react-utils: 0.17.0-next.27(@types/react@18.3.1)(react@19.0.0)
       react: 19.0.0
     transitivePeerDependencies:
@@ -12003,6 +12052,27 @@ snapshots:
       - react-dom
 
   '@storacha/upload-client@1.2.3(encoding@0.1.13)':
+    dependencies:
+      '@ipld/car': 5.4.2
+      '@ipld/dag-cbor': 9.2.2
+      '@ipld/dag-ucan': 3.4.5
+      '@ipld/unixfs': 3.0.0
+      '@storacha/blob-index': 1.1.0
+      '@storacha/capabilities': 1.7.0
+      '@storacha/filecoin-client': 1.0.9
+      '@ucanto/client': 9.0.1
+      '@ucanto/core': 10.4.0
+      '@ucanto/interface': 10.3.0
+      '@ucanto/transport': 9.2.0
+      '@web3-storage/data-segment': 5.3.0
+      ipfs-utils: 9.0.14(encoding@0.1.13)
+      multiformats: 13.3.6
+      p-retry: 5.1.2
+      varint: 6.0.0
+    transitivePeerDependencies:
+      - encoding
+
+  '@storacha/upload-client@1.2.4(encoding@0.1.13)':
     dependencies:
       '@ipld/car': 5.4.2
       '@ipld/dag-cbor': 9.2.2
@@ -15987,13 +16057,13 @@ snapshots:
       camelcase-css: 2.0.1
       postcss: 8.5.2
 
-  postcss-load-config@4.0.2(postcss@8.5.2)(ts-node@10.9.1(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@20.0.0)(typescript@5.5.4)):
+  postcss-load-config@4.0.2(postcss@8.5.2)(ts-node@9.1.1(typescript@5.5.4)):
     dependencies:
       lilconfig: 3.1.3
       yaml: 2.7.0
     optionalDependencies:
       postcss: 8.5.2
-      ts-node: 10.9.1(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@20.0.0)(typescript@5.5.4)
+      ts-node: 9.1.1(typescript@5.5.4)
 
   postcss-nested@6.2.0(postcss@8.5.2):
     dependencies:
@@ -16764,11 +16834,11 @@ snapshots:
 
   tailwind-merge@2.5.5: {}
 
-  tailwindcss-animate@1.0.7(tailwindcss@3.4.1(ts-node@10.9.1(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@20.0.0)(typescript@5.5.4))):
+  tailwindcss-animate@1.0.7(tailwindcss@3.4.1(ts-node@9.1.1(typescript@5.5.4))):
     dependencies:
-      tailwindcss: 3.4.1(ts-node@10.9.1(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@20.0.0)(typescript@5.5.4))
+      tailwindcss: 3.4.1(ts-node@9.1.1(typescript@5.5.4))
 
-  tailwindcss@3.4.1(ts-node@10.9.1(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@20.0.0)(typescript@5.5.4)):
+  tailwindcss@3.4.1(ts-node@9.1.1(typescript@5.5.4)):
     dependencies:
       '@alloc/quick-lru': 5.2.0
       arg: 5.0.2
@@ -16787,7 +16857,7 @@ snapshots:
       postcss: 8.5.2
       postcss-import: 15.1.0(postcss@8.5.2)
       postcss-js: 4.0.1(postcss@8.5.2)
-      postcss-load-config: 4.0.2(postcss@8.5.2)(ts-node@10.9.1(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@20.0.0)(typescript@5.5.4))
+      postcss-load-config: 4.0.2(postcss@8.5.2)(ts-node@9.1.1(typescript@5.5.4))
       postcss-nested: 6.2.0(postcss@8.5.2)
       postcss-selector-parser: 6.1.2
       resolve: 1.22.10
@@ -16994,27 +17064,6 @@ snapshots:
     optionalDependencies:
       '@swc/core': 1.11.29(@swc/helpers@0.5.17)
 
-  ts-node@10.9.1(@swc/core@1.11.29(@swc/helpers@0.5.17))(@types/node@20.0.0)(typescript@5.5.4):
-    dependencies:
-      '@cspotcode/source-map-support': 0.8.1
-      '@tsconfig/node10': 1.0.11
-      '@tsconfig/node12': 1.0.11
-      '@tsconfig/node14': 1.0.3
-      '@tsconfig/node16': 1.0.4
-      '@types/node': 20.0.0
-      acorn: 8.14.1
-      acorn-walk: 8.3.4
-      arg: 4.1.3
-      create-require: 1.1.1
-      diff: 4.0.2
-      make-error: 1.3.6
-      typescript: 5.5.4
-      v8-compile-cache-lib: 3.0.1
-      yn: 3.1.1
-    optionalDependencies:
-      '@swc/core': 1.11.29(@swc/helpers@0.5.17)
-    optional: true
-
   ts-node@9.1.1(typescript@4.9.5):
     dependencies:
       arg: 4.1.3
@@ -17024,6 +17073,17 @@ snapshots:
       source-map-support: 0.5.21
       typescript: 4.9.5
       yn: 3.1.1
+
+  ts-node@9.1.1(typescript@5.5.4):
+    dependencies:
+      arg: 4.1.3
+      create-require: 1.1.1
+      diff: 4.0.2
+      make-error: 1.3.6
+      source-map-support: 0.5.21
+      typescript: 5.5.4
+      yn: 3.1.1
+    optional: true
 
   ts-toolbelt@6.15.5: {}
 


### PR DESCRIPTION
Right now users see a pricing table in the authorization email they get from us. This redirects them back to the console after authorizing, which is not what we want. This PR allows clients to set an appName that will prevent the pricing table from being shown.