### PR TITLE
fix(storacha): give upload/get + space/blob/get caps

### DIFF
--- a/app/lib/storacha.ts
+++ b/app/lib/storacha.ts
@@ -120,10 +120,12 @@ export const createServerDelegations = async (
     issuer: client.agent.issuer,
     audience: audienceDID,
     capabilities: [
+      { can: SpaceBlob.get.can, with: space.did() },
       { can: SpaceBlob.add.can, with: space.did() },
       { can: SpaceBlob.remove.can, with: space.did() },
       { can: SpaceIndex.add.can, with: space.did() },
       { can: Upload.add.can, with: space.did() },
+      { can: Upload.get.can, with: space.did() },
       { can: Upload.remove.can, with: space.did() },
       { can: SSstore.remove.can, with: space.did() },
       { can: Filecoin.offer.can, with: space.did() },


### PR DESCRIPTION
# Goals

Fix this when I try to delete backups:
<img width="387" height="647" alt="Screenshot 2025-07-23 at 4 56 20 PM" src="https://github.com/user-attachments/assets/a1a40c8e-d2c4-4c6d-926b-e2d79aa0c63b" />

I did some debugging and found it was failing on an `upload/get` call which I guess happens in client.remove when {shards: true} is passed.

# Implementation

- add additional capabilities upload/get & space/blob/get so backup deletion doesn't fail