### PR TITLE
fix: log and capture auth errors _after_ setting state

### DIFF
--- a/app/components/telegram-auth.tsx
+++ b/app/components/telegram-auth.tsx
@@ -351,8 +351,8 @@ export default function TelegramAuth() {
       if (errorMsg.includes('PASSWORD_HASH_INVALID')) {
         setError(new Error('Your password was incorrect. Please try again.'))
       } else {
-        logAndCaptureError(err)
         setError(err)
+        logAndCaptureError(err)
       }
     } finally {
       setLoading(false)

--- a/app/lib/sentry.ts
+++ b/app/lib/sentry.ts
@@ -7,5 +7,10 @@ import { captureException } from '@sentry/nextjs'
  */
 export function logAndCaptureError(err: unknown) {
   console.error(err)
-  captureException(err)
+  try {
+    captureException(err)
+  } catch (e) {
+    console.error('error sending error to Sentry:', err)
+    console.error("the error from Sentry's captureException is:", e)
+  }
 }


### PR DESCRIPTION
There's something going wrong with this code in production and I suspect it's an issue sending the error to Sentry.

This PR:

1) sets the error state before trying to send to Sentry 2) adds a try...catch to logAndCaptureError to capture and log errors in this process