### PR TITLE
fix: add StorachaConnect on date page for first login users

### DIFF
--- a/app/app/backup/page.tsx
+++ b/app/app/backup/page.tsx
@@ -55,15 +55,17 @@ export default function Page() {
           onSubmit={() => setStep(1)}
         />
       )}
-      {(step === 1 || (step === 2 && (!isStorachaAuthorized || !space))) && (
-        <Dates
-          period={period}
-          onPeriodChange={setPeriod}
-          onSubmit={() => setStep(2)}
-        />
-      )}
-      {step === 2 && !isStorachaAuthorized && (
-        <StorachaConnect open={true} onDismiss={() => setStep(1)} />
+      {step === 1 && (
+        <>
+          <Dates
+            period={period}
+            onPeriodChange={setPeriod}
+            onSubmit={() => setStep(2)}
+          />
+          {!isStorachaAuthorized && (
+            <StorachaConnect open={true} onDismiss={() => setStep(0)} />
+          )}
+        </>
       )}
       {step === 2 && isStorachaAuthorized && space && (
         <Summary

--- a/app/components/backup/dates.tsx
+++ b/app/components/backup/dates.tsx
@@ -40,7 +40,7 @@ export default function Dates({
     period[1] ? new Date(period[1] * 1000) : now, // to
   ])
 
-  const accountDid = accounts[0].did()
+  const accountDid = accounts[0]?.did()
   const [fromDate, toDate] = dates
   const maxWeeks = paying
     ? MAX_BACKUP_WEEKS_PAID_TIER
@@ -51,7 +51,7 @@ export default function Dates({
 
     const checkPaymentStatus = async () => {
       try {
-        if (!client) return
+        if (!client || !accountDid) return
         const result = await isPayingAccount(client, accountDid)
         if (mounted) setPaying(result)
       } catch (err) {


### PR DESCRIPTION
The date page didn't used to require a user's Storacha account, so we didn't require first login users to log in to Storacha until later. That's no longer the case since we limit date ranges for non-paying users. Handle no account cleanly and move the Storach login dialog up a screen for first time login users.