### PR TITLE
chore: update contributing guide and add a process for PR reviews

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,6 +6,7 @@
 - [ ] I ran linting and formatting commands
 - [ ] I acknowledge that if changes are requested and I don’t respond within 10 days, this PR may be marked stale and closed after an additional 4 days. I can ask to reopen or open a new PR later.
 - [ ] I have read and agree to follow the [Contribution Guidelines](../CONTRIBUTING.md)
+- [ ] I have added screenshots or screen captures demonstrating any new visual elements or UI
 
 ## Notes for Reviewers (optional)
 <!-- Anything specific you want feedback on, or that reviewers should know? -->

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,11 @@
+## Description
+<!-- Briefly describe what this PR does and why. If it fixes or relates to an issue, link it here. -->
+
+## Checklist
+- [ ] I verified the change locally (builds and app functionality)
+- [ ] I ran linting and formatting commands
+- [ ] I acknowledge that if changes are requested and I don’t respond within 10 days, this PR may be marked stale and closed after an additional 4 days. I can ask to reopen or open a new PR later.
+- [ ] I have read and agree to follow the [Contribution Guidelines](../CONTRIBUTING.md)
+
+## Notes for Reviewers (optional)
+<!-- Anything specific you want feedback on, or that reviewers should know? -->

--- a/.github/scripts/pr-triage.js
+++ b/.github/scripts/pr-triage.js
@@ -1,0 +1,94 @@
+
+/**
+ * Behavior:
+ * - Review (changes_requested) on a non-draft PR: add awaiting-author, remove awaiting-review
+ * - Review (approved): remove awaiting-author
+ * - PR events (synchronize, reopened, ready_for_review) when not draft: remove awaiting-author, add awaiting-review
+ * - Converted to draft OR currently draft: remove awaiting-author & awaiting-review (pause timers)
+ */
+
+/** 
+ * @param {Object} params
+ * @param {import('github-script').Context} params.context
+ * @param {import('@octokit/rest').Octokit} params.github
+ * @param {import('@actions/core')} params.core
+ */
+module.exports = async ({github, context, core})=> {
+    const pr = context.payload.pull_request || context.payload.review?.pull_request
+    if (!pr) return
+
+    const { owner, repo } = context.repo
+    const issue_number = pr.number
+
+    const currentLabels = (pr.labels || []).map(l => (typeof l === 'string' ? l : l.name))
+    const hasAwaitingAuthor = currentLabels.includes('awaiting-author')
+
+    async function add(label) {
+        try {
+            await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] })
+            core.info(`Added label: ${label}`)
+        } catch (e) {
+            if (e.status !== 422) throw e // already has label
+        }
+    }
+
+    async function remove(label) {
+        try {
+            await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label })
+            core.info(`Removed label: ${label}`)
+        } catch (e) {
+            if (e.status !== 404) throw e // label not present
+        }
+    }
+
+    if (context.eventName === 'pull_request_review') {
+        if (pr.draft) {
+            core.info('PR is draft, ignoring review event.')
+            return
+        }
+
+        const state = (context.payload.review.state || '').toLowerCase()
+        core.info(`Review state: ${state}`)
+
+        if (state === 'changes_requested') {
+            await add('awaiting-author')
+            await remove('awaiting-review')
+        } else if (state === 'approved') {
+            await remove('awaiting-author')
+        }
+    }
+
+    if (context.eventName === 'pull_request') {
+        const action = context.payload.action
+        core.info(`PR action: ${action}`)
+
+        if (action === 'converted_to_draft' || pr.draft) {
+            core.info('Clearing labels because PR is draft or was converted to draft.')
+            await remove('awaiting-author')
+            await remove('awaiting-review')
+            return
+        }
+
+         if (action === 'review_requested') {
+            core.info('Update label to awaiting-review because review was requested.')
+            await remove('awaiting-author')
+            await add('awaiting-review')
+            return
+         }
+       
+        if (['reopened', 'ready_for_review'].includes(action)) {
+            core.info('PR updated (commit/reopen/ready), switching to awaiting-review.')
+            await remove('awaiting-author')
+            await add('awaiting-review')
+        }
+
+        if (action === 'synchronize') {
+            if (hasAwaitingAuthor) {
+                core.info('Commit pushed while awaiting-author, keeping awaiting-author label.')
+                return
+            }
+            core.info('Commit pushed, adding awaiting-review label.')
+            await add('awaiting-review')
+        }
+    }
+}

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -1,0 +1,72 @@
+name: PR triage labels
+
+on:
+  pull_request_review:
+    types: [submitted, edited, dismissed]
+  pull_request:
+    types: [synchronize, reopened, ready_for_review, converted_to_draft]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  label-awaiting-author:
+    name: Manage awaiting-author/awaiting-review labels
+    runs-on: ubuntu-latest
+    steps:
+      - name: Apply/remove labels based on review state or new commits
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const pr = context.payload.pull_request || context.payload.review?.pull_request;
+            if (!pr) return;
+
+            const owner = context.repo.owner;
+            const repo = context.repo.repo;
+            const issue_number = pr.number;
+
+            async function add(label) {
+              try {
+                await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
+              } catch (e) {
+                if (e.status !== 422) throw e; // already has label
+              }
+            }
+            async function remove(label) {
+              try {
+                await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label });
+              } catch (e) {
+                if (e.status !== 404) throw e; // label not present
+              }
+            }
+
+            if (context.eventName === 'pull_request_review') {
+              // Ignore formal review state on draft PRs
+              if (pr.draft) return;
+
+              const state = (context.payload.review.state || '').toLowerCase();
+              if (state === 'changes_requested') {
+                await add('awaiting-author');
+                await remove('awaiting-review').catch(() => {});
+              } else if (state === 'approved') {
+                await remove('awaiting-author').catch(() => {});
+              }
+            }
+
+            if (context.eventName === 'pull_request') {
+              const action = context.payload.action;
+
+              // If converted to draft or currently draft, clear awaiting-* labels
+              if (action === 'converted_to_draft' || pr.draft) {
+                await remove('awaiting-author').catch(() => {});
+                await remove('awaiting-review').catch(() => {});
+                return;
+              }
+
+              // New commits, reopened, or made ready for review -> waiting on reviewers
+              if (['synchronize', 'reopened', 'ready_for_review'].includes(action)) {
+                await remove('awaiting-author').catch(() => {});
+                await add('awaiting-review').catch(() => {});
+              }
+            }

--- a/.github/workflows/pr-triage.yml
+++ b/.github/workflows/pr-triage.yml
@@ -4,69 +4,24 @@ on:
   pull_request_review:
     types: [submitted, edited, dismissed]
   pull_request:
-    types: [synchronize, reopened, ready_for_review, converted_to_draft]
+    types: [synchronize, reopened, ready_for_review, converted_to_draft, review_requested]
 
 permissions:
   contents: read
   pull-requests: write
+  issues: write
 
 jobs:
   label-awaiting-author:
     name: Manage awaiting-author/awaiting-review labels
     runs-on: ubuntu-latest
     steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
       - name: Apply/remove labels based on review state or new commits
         uses: actions/github-script@v7
         with:
           script: |
-            const pr = context.payload.pull_request || context.payload.review?.pull_request;
-            if (!pr) return;
-
-            const owner = context.repo.owner;
-            const repo = context.repo.repo;
-            const issue_number = pr.number;
-
-            async function add(label) {
-              try {
-                await github.rest.issues.addLabels({ owner, repo, issue_number, labels: [label] });
-              } catch (e) {
-                if (e.status !== 422) throw e; // already has label
-              }
-            }
-            async function remove(label) {
-              try {
-                await github.rest.issues.removeLabel({ owner, repo, issue_number, name: label });
-              } catch (e) {
-                if (e.status !== 404) throw e; // label not present
-              }
-            }
-
-            if (context.eventName === 'pull_request_review') {
-              // Ignore formal review state on draft PRs
-              if (pr.draft) return;
-
-              const state = (context.payload.review.state || '').toLowerCase();
-              if (state === 'changes_requested') {
-                await add('awaiting-author');
-                await remove('awaiting-review').catch(() => {});
-              } else if (state === 'approved') {
-                await remove('awaiting-author').catch(() => {});
-              }
-            }
-
-            if (context.eventName === 'pull_request') {
-              const action = context.payload.action;
-
-              // If converted to draft or currently draft, clear awaiting-* labels
-              if (action === 'converted_to_draft' || pr.draft) {
-                await remove('awaiting-author').catch(() => {});
-                await remove('awaiting-review').catch(() => {});
-                return;
-              }
-
-              // New commits, reopened, or made ready for review -> waiting on reviewers
-              if (['synchronize', 'reopened', 'ready_for_review'].includes(action)) {
-                await remove('awaiting-author').catch(() => {});
-                await add('awaiting-review').catch(() => {});
-              }
-            }
+            const triage = require('./.github/scripts/pr-triage.js')
+            await triage({ github, context, core })

--- a/.github/workflows/stale-prs.yml
+++ b/.github/workflows/stale-prs.yml
@@ -1,0 +1,42 @@
+name: Auto-mark and close stale PRs awaiting author
+
+on:
+  schedule:
+    - cron: "0 3 * * *" # daily at 03:00 UTC
+  workflow_dispatch:
+
+permissions:
+  pull-requests: write
+  contents: read
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Only act on PRs that are awaiting author updates
+          only-pr-labels: awaiting-author
+
+          # Exempt draft PRs entirely
+          exempt-draft-pr: true
+
+          # Timeline: mark stale after 10 days of inactivity, close 4 days later
+          days-before-stale: 10
+          days-before-close: 4
+
+          # Labels and messages
+          stale-pr-label: stale
+          exempt-pr-labels: blocked,security,maintainer-will-finish
+          remove-stale-when-updated: true
+
+          stale-pr-message: |
+            This pull request has been marked as stale because changes were requested and there has been no activity for 10 days.
+            If you plan to continue, please push commits or leave a comment. Otherwise, this PR will be closed in 4 days.
+            Maintainers can add an exemption label if needed.
+
+          close-pr-message: |
+            Closing this pull request due to inactivity after requested changes.
+            If you’d like to continue, please push updates and ask a maintainer to reopen, or open a new PR referencing this one. Thanks!

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing! Storacha is open-source and welcomes c
 
 This is a full-stack app built with [Next.js](https://nextjs.org/) using Node.js v18 and [pnpm](https://pnpm.io/). Since it’s a Telegram Mini App, it doesn't run like a traditional web app — it must be launched inside Telegram and linked to a bot.
 
-If you're submitting a pull request, be sure to follow our  [PR Guidelines](#pr-guidelines).
+If you're submitting a pull request, be sure to follow our [PR Guidelines](#pr-guidelines).
 
 ## 🛠️ Local Development Setup
 
@@ -231,6 +231,7 @@ To keep maintenance sustainable, we follow a predictable timeline:
 ### Tips for a Smooth Contribution
 
 - **AI-assisted changes:** If you used AI to help with your contribution:
+  - Thoroughly review all AI generated code - you **MUST** understand and be able to answer questions about all code you submit in a PR.
   - Run and verify the code locally.
   - Be ready to adjust based on review feedback.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thanks for your interest in contributing! Storacha is open-source and welcomes c
 
 This is a full-stack app built with [Next.js](https://nextjs.org/) using Node.js v18 and [pnpm](https://pnpm.io/). Since it’s a Telegram Mini App, it doesn't run like a traditional web app — it must be launched inside Telegram and linked to a bot.
 
-If you're submitting a pull request, be sure to follow our [commit message guidelines](#how-should-i-write-my-commits).
+If you're submitting a pull request, be sure to follow our  [PR Guidelines](#pr-guidelines).
 
 ## 🛠️ Local Development Setup
 
@@ -177,12 +177,61 @@ While the Bot API lets you interact with your own bot, it **does not** provide a
 These credentials allow your app to authenticate as a user (not just a bot) and access messages and chat history through TDLib.
 
 
-## 📝 How should I write my commits?
+## PR Guidelines
+
+We welcome and value contributions from the community! To help us review and merge your pull request (PR) efficiently, please follow these guidelines:
+
+### 📝 How should I write my commits?
 
 We use [Conventional Commits](https://www.conventionalcommits.org/) to power automatic changelogs and releases via [Release Please](https://github.com/googleapis/release-please).
 
-### Use these prefixes:
+#### Use these prefixes:
 
 - `fix:` – Bug fixes → _SemVer patch_
 - `feat:` – New features → _SemVer minor_
+- `chore:`- tasks that don't directly impact the functionality of your application but are important for maintaining a clean, functional codebase
 - `feat!:`, `fix!:`, etc. – Breaking changes → _SemVer major_
+
+### Before You Open a PR
+
+- **Describe your change clearly:** Summarize what your PR does and why. If it addresses an issue, link to it in the description.
+
+- **Keep PRs focused:** Submit small, focused PRs that address a single topic or problem. Large or unrelated changes are harder to review and may be delayed.
+
+- **Follow the code style:** Match the existing code style and patterns. Run linting and formatting using the commands defined in `app/package.json`.
+
+- **Test your changes:** Run the app and verify your changes work as expected.
+
+
+### Review & Merge Process
+
+To keep maintenance sustainable, we follow a predictable timeline:
+
+1. **Review:**
+  - A reviewer will provide specific, actionable feedback and mark the PR as “Changes requested”.
+  - The PR will be labeled `awaiting-author`.
+
+2. **Response Window:**
+  - If there is no response (commits or comments) within 10 days, the PR will be marked as `stale`.
+  - If there is still no activity after an additional 4 days, the PR may be closed.
+
+3. **Reopening & Exceptions:**
+  - If your PR is closed, you can:
+    - Push new commits to the same branch and ask a maintainer to reopen, or
+    - Open a new PR referencing the closed one.
+  - Maintainers may exempt PRs from closure if they are:
+    - Labeled `blocked` or `maintainer-will-finish`,
+    - Clearly in-progress with active discussion, or
+    - Time-sensitive and acknowledged by maintainers.
+
+4. **Reviewer Responsibilities:**
+  - Provide a concise summary and a checklist of requested changes.
+  - Clearly distinguish between blocking and optional feedback.
+
+### Tips for a Smooth Contribution
+
+- **AI-assisted changes:** If you used AI to help with your contribution:
+  - Run and verify the code locally.
+  - Be ready to adjust based on review feedback.
+
+- **Celebrate your contribution:** We appreciate every PR, thank you for helping improve Storacha!


### PR DESCRIPTION
This PR introduces clearer contribution guidelines and an automated review workflow to improve PR quality and reduce inactive pull requests after changes are requested.

### Changes:

- Added labels: `awaiting-author`, `awaiting-review`, `blocked`, `security`, `maintainer-will-finish`, `stale`
- Added workflows:
  1. `pr-triage.yml`
     - Adds `awaiting-author` when changes are requested
     - Adds `awaiting-review` on new commits or when marked `ready_for_review`
     - Clears those labels when a PR is in draft
  2. `stale-prs.yml`
     - Marks `awaiting-author` PRs as `stale` after 10 days of inactivity and closes them 4 days later
     - Exempts draft PRs and those labeled `blocked`, `security`, or `maintainer-will-finish`