### PR TITLE
fix: prevent calendar popover from overflowing screen

### DIFF
--- a/app/components/backup/dates.tsx
+++ b/app/components/backup/dates.tsx
@@ -217,19 +217,21 @@ export default function Dates({ onPeriodChange, onSubmit }: DatesProps) {
                   </Button>
                 </PopoverTrigger>
                 <PopoverContent className="w-auto p-0">
-                  <Calendar
-                    mode="single"
-                    selected={date ?? undefined}
-                    onSelect={(d) => d && updateDate(i)(d)}
-                    disabled={(d) => d > now}
-                    defaultMonth={date ?? now}
-                    modifiers={getDisabledDates(i)}
-                    modifiersClassNames={{
-                      invalid:
-                        'text-muted-foreground opacity-40 cursor-not-allowed',
-                    }}
-                    autoFocus
-                  />
+                  <div className="max-h-[300px] overflow-y-auto">
+                    <Calendar
+                      mode="single"
+                      selected={date ?? undefined}
+                      onSelect={(d) => d && updateDate(i)(d)}
+                      disabled={(d) => d > now}
+                      defaultMonth={date ?? now}
+                      modifiers={getDisabledDates(i)}
+                      modifiersClassNames={{
+                        invalid:
+                          'text-muted-foreground opacity-40 cursor-not-allowed',
+                      }}
+                      autoFocus
+                    />
+                  </div>
                 </PopoverContent>
               </Popover>
             </div>


### PR DESCRIPTION
## Description
 - Prevents the date picker calendar from extending beyond screen
 
On Mac app:
<video src="https://github.com/user-attachments/assets/e87cdc4c-5d26-4ea2-ae42-182df485ac16" width="300" controls></video>

On mobile:
<img src="https://github.com/user-attachments/assets/ab65d7bd-aaf4-4748-b7e8-d2eda02bf491" width="300" />



## Checklist
- [x] I verified the change locally (builds and app functionality)
- [x] I ran linting and formatting commands
- [x] I acknowledge that if changes are requested and I don’t respond within 10 days, this PR may be marked stale and closed after an additional 4 days. I can ask to reopen or open a new PR later.
- [x] I have read and agree to follow the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I have added screenshots or screen captures demonstrating any new visual elements or UI
