### PR TITLE
fix(telegram): correct callback memoization

### DIFF
--- a/app/components/root.tsx
+++ b/app/components/root.tsx
@@ -164,7 +164,7 @@ const BackupProviderContainer = ({ children }: PropsWithChildren) => {
       await storacha.setCurrentSpace(space)
 
       try {
-        fromResult(
+        await fromResult(
           await login({
             telegramAuth: {
               session: tgSessionString,

--- a/app/providers/telegram.tsx
+++ b/app/providers/telegram.tsx
@@ -23,6 +23,7 @@ import { useGlobal } from '@/zustand/global'
 import { DialogInfo } from '@/api'
 import { fromResult, getErrorMessage } from '@/lib/errorhandling'
 import { useError } from './error'
+import { useRouter } from 'next/navigation'
 
 export interface ContextState {
   launchParams: LaunchParams
@@ -72,6 +73,7 @@ export const Provider = ({ children }: PropsWithChildren): ReactNode => {
   const [isTgAuthorized, setIsTgAuthorized] = useState(false)
   const [isValidating, setIsValidating] = useState(true)
   const { setError } = useError()
+  const router = useRouter()
 
   const user = useSignal(initData.user)
   const launchParams = useLaunchParams()
@@ -127,6 +129,10 @@ export const Provider = ({ children }: PropsWithChildren): ReactNode => {
       setIsTgAuthorized(false)
       if (!tgSessionString) return
       await logoutTelegram(tgSessionString)
+      // we clear the TG session string once we are successfully logged out
+      setTgSessionString('')
+      // redirect to home page after logout
+      router.push('/')
     } catch (err) {
       const title = 'Failed to log out from Telegram!'
       console.error(title, err)
@@ -178,7 +184,7 @@ export const Provider = ({ children }: PropsWithChildren): ReactNode => {
       setError(getErrorMessage(err), { title: 'Error fetching user info' })
       return undefined
     }
-  }, [])
+  }, [tgSessionString])
 
   return (
     <Context.Provider


### PR DESCRIPTION
## Description

fix #292 

The key change here is to add the tgSessionString to the list of variables that update the memoization of the callback function. The reason for the error is that because tgSessionString was not in that list, the getMe callback would never update. The reason it only shows up on the view backup page is because... apparently that's the only place it's called.

I added a couple other QoL improvements here:
1. If you log out while not on the homepage, after you log into telegram again, you end up back on whatever page you're on, which can be unpredictable, because you're no longer auth'd to Storacha. I definitely got an empty backups list page for example. I added switching back to the homepage after logout. I also clear the TGSessionString to be safe.
2. Found a try catch that isn't waiting for an async function to finish, which makes the catch never get called. dunno if this was actually causing any problems, but clearly needs to be fixed.

## Checklist
- [x ] I verified the change locally (builds and app functionality)
- [ x] I ran linting and formatting commands
- [x ] I acknowledge that if changes are requested and I don’t respond within 10 days, this PR may be marked stale and closed after an additional 4 days. I can ask to reopen or open a new PR later.
- [ x] I have read and agree to follow the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] I have added screenshots or screen captures demonstrating any new visual elements or UI

## Notes for Reviewers (optional)
<!-- Anything specific you want feedback on, or that reviewers should know? -->