### PR TITLE
fix: handle invalid init date with logout

### DIFF
--- a/app/components/layouts/menu.tsx
+++ b/app/components/layouts/menu.tsx
@@ -9,19 +9,12 @@ import { AlignJustify, LogOut } from 'lucide-react'
 import { useTelegram } from '@/providers/telegram'
 import { useGlobal } from '@/zustand/global'
 import { MouseEventHandler } from 'react'
-import { useW3 as useStoracha } from '@storacha/ui-react'
+import { useLogout } from '@/hooks/useLogout'
 
 export function Menu() {
-  const [{ user }, { logout: telegramLogout }] = useTelegram()
-  const [, { logout }] = useStoracha()
-  const {
-    phoneNumber,
-    setIsStorachaAuthorized,
-    setPhoneNumber,
-    setSpace,
-    setTgSessionString,
-    setUser,
-  } = useGlobal()
+  const [{ user }] = useTelegram()
+  const { phoneNumber } = useGlobal()
+  const logout = useLogout()
   const initials = user?.firstName
     ? (user.firstName[0] + (user?.lastName?.[0] ?? '')).toUpperCase()
     : ''
@@ -29,15 +22,7 @@ export function Menu() {
   const handleLogOutClick: MouseEventHandler<HTMLButtonElement> = async (e) => {
     e.preventDefault()
     if (!confirm('Are you sure you want to log out?')) return
-    localStorage.removeItem('GramJs:apiCache')
-    sessionStorage.clear()
-    await telegramLogout()
-    setPhoneNumber('')
-    setSpace(null)
-    setTgSessionString('')
-    setUser(null)
     await logout()
-    setIsStorachaAuthorized(false)
   }
 
   return (

--- a/app/components/root.tsx
+++ b/app/components/root.tsx
@@ -36,6 +36,7 @@ import TelegramAuth from './telegram-auth'
 import LogoSplash from './svgs/logo-splash'
 import { ErrorBoundary } from './error-boundary'
 import { useDidMount } from '../hooks/useDidMount'
+import { useLogout } from '@/hooks/useLogout'
 
 const version = process.env.NEXT_PUBLIC_VERSION ?? '0.0.0'
 const serverDID = parseDID(process.env.NEXT_PUBLIC_SERVER_DID ?? '')
@@ -136,6 +137,7 @@ const BackupProviderContainer = ({ children }: PropsWithChildren) => {
   } = useGlobal()
   const [jobs, setJobs] = useState<JobStorage>()
   const { setError } = useError()
+  const logout = useLogout()
 
   useEffect(() => {
     let eventSource: EventSource
@@ -176,6 +178,7 @@ const BackupProviderContainer = ({ children }: PropsWithChildren) => {
         )
       } catch (err) {
         setError(getErrorMessage(err), { title: 'Error logging in!' })
+        await logout()
         return
       }
 

--- a/app/hooks/useLogout.ts
+++ b/app/hooks/useLogout.ts
@@ -1,0 +1,29 @@
+import { useCallback } from 'react'
+import { useError } from '@/providers/error'
+import { useGlobal } from '@/zustand/global'
+import { useTelegram } from '@/providers/telegram'
+import { getErrorMessage } from '@/lib/errorhandling'
+import { useW3 as useStoracha } from '@storacha/ui-react'
+
+export const useLogout = (): (() => Promise<void>) => {
+  const [, { logout: storachaLogout }] = useStoracha()
+  const [, { logout: telegramLogout }] = useTelegram()
+  const { clearAuthState } = useGlobal()
+  const { setError } = useError()
+
+  return useCallback(async () => {
+    await telegramLogout()
+
+    try {
+      await storachaLogout()
+    } catch (err) {
+      setError(getErrorMessage(err), {
+        title: 'Failed to log out from Storacha!',
+      })
+    }
+    // Clear all auth-related state
+    clearAuthState()
+    sessionStorage.clear()
+    localStorage.removeItem('GramJs:apiCache')
+  }, [storachaLogout, telegramLogout, clearAuthState, setError])
+}

--- a/app/providers/telegram.tsx
+++ b/app/providers/telegram.tsx
@@ -105,8 +105,7 @@ export const Provider = ({ children }: PropsWithChildren): ReactNode => {
         const errorMsg = getErrorMessage(err)
         if (errorMsg.includes('client authorization failed')) {
           console.log('Session validation failed, clearing session')
-          setTgSessionString('')
-          setIsTgAuthorized(false)
+          await logout()
         }
       } finally {
         setIsValidating(false)
@@ -131,6 +130,7 @@ export const Provider = ({ children }: PropsWithChildren): ReactNode => {
       await logoutTelegram(tgSessionString)
       // we clear the TG session string once we are successfully logged out
       setTgSessionString('')
+      setIsTgAuthorized(false)
       // redirect to home page after logout
       router.push('/')
     } catch (err) {

--- a/app/zustand/global.ts
+++ b/app/zustand/global.ts
@@ -64,6 +64,7 @@ interface GlobalState {
   setPhoneNumber: (phone: string) => void
   setSpace: (space: SpaceDID | null) => void
   setTgSessionString: (session?: Session | string) => void
+  clearAuthState: () => void
 }
 
 // Create a factory function that generates user-specific stores
@@ -87,6 +88,14 @@ const createUserGlobalStore = (userId: number) => {
         setSpace: (space) => set({ space }),
         setTgSessionString: (tgSessionString) =>
           set({ tgSessionString: saveSessionToString(tgSessionString) }),
+        clearAuthState: () =>
+          set({
+            isStorachaAuthorized: false,
+            user: null,
+            phoneNumber: '',
+            space: null,
+            tgSessionString: '',
+          }),
       }),
       {
         name: `global-storage-${userId}`, // Each user gets their own storage key


### PR DESCRIPTION
## Description
Fix the issue where the app tries to log in with invalid init data by logging the user out. Also, create a reusable logout hook.<img width="300" height="700" alt="image" src="https://github.com/user-attachments/assets/af9df0aa-529b-4033-b9fa-fe41ee25b117" />


## Checklist
- [x] I verified the change locally (builds and app functionality)
- [x] I ran linting and formatting commands
- [x] I acknowledge that if changes are requested and I don’t respond within 10 days, this PR may be marked stale and closed after an additional 4 days. I can ask to reopen or open a new PR later.
- [x] I have read and agree to follow the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] I have added screenshots or screen captures demonstrating any new visual elements or UI

