### PR TITLE
Multiple bug fixes: AUTH_KEY_DUPLICATED, initData expired, missing client disconnect

### DIFF
--- a/app/api.ts
+++ b/app/api.ts
@@ -156,6 +156,12 @@ export interface TelegramAuth {
 export interface LoginRequest {
   accountDID: AccountDID
   spaceDID: SpaceDID
+  session: string
+}
+
+export interface RequestAuth {
+  accountDID: AccountDID
+  spaceDID: SpaceDID
   telegramAuth: TelegramAuth
 }
 
@@ -163,11 +169,12 @@ export interface ExecuteAuth {
   spaceDelegation: Uint8Array
   encryptionPassword: string
 }
-export interface ExecuteJobRequest extends ExecuteAuth, LoginRequest {
+
+export interface ExecuteJobRequest extends ExecuteAuth, RequestAuth {
   jobID: JobID
 }
 
-export interface DeleteDialogFromJob extends ExecuteAuth, LoginRequest {
+export interface DeleteDialogFromJob extends ExecuteAuth, RequestAuth {
   jobID: JobID
   dialogID: ToString<EntityID>
 }

--- a/app/app/api/entity/[id]/image/route.ts
+++ b/app/app/api/entity/[id]/image/route.ts
@@ -27,14 +27,19 @@ async function getHiResPhotoBlob(
   id: string,
   accessHash?: string
 ): Promise<Result<string | Buffer | undefined>> {
+  let client: TelegramClient | undefined = undefined
   try {
-    const client = await getTelegramClient(sessionString)
+    client = await getTelegramClient(sessionString)
     const entity = await tryHardToFetchEntity(client, id, accessHash)
     return { ok: await client.downloadProfilePhoto(entity) }
   } catch (e) {
     // @ts-expect-error e has no type, ignore
     const message = e.message
     return { error: { message } }
+  } finally {
+    if (client) {
+      await client.disconnect()
+    }
   }
 }
 

--- a/app/components/root.tsx
+++ b/app/components/root.tsx
@@ -30,6 +30,7 @@ import {
   removeJob,
   cancelJob,
   deleteDialogFromJob,
+  storeInitData,
 } from './server'
 import { ErrorPage } from './error'
 import TelegramAuth from './telegram-auth'
@@ -164,12 +165,10 @@ const BackupProviderContainer = ({ children }: PropsWithChildren) => {
       await storacha.setCurrentSpace(space)
 
       try {
-        await fromResult(
+        fromResult(await storeInitData(launchParams.initDataRaw || ''))
+        fromResult(
           await login({
-            telegramAuth: {
-              session: tgSessionString,
-              initData: launchParams.initDataRaw || '',
-            },
+            session: tgSessionString,
             spaceDID: space,
             accountDID: user.accountDID,
           })

--- a/app/lib/server/jobs.ts
+++ b/app/lib/server/jobs.ts
@@ -5,9 +5,9 @@ import {
   CreateJobRequest,
   FindJobRequest,
   RemoveJobRequest,
-  LoginRequest,
   CancelJobRequest,
   DeleteDialogFromJobRequest,
+  LoginRequest,
 } from '@/api'
 import { Delegation, DID, Signer } from '@ucanto/client'
 import { Client as StorachaClient } from '@storacha/client'
@@ -27,15 +27,23 @@ import {
 import { extract } from '@ucanto/core/delegation'
 import { getTelegramClient } from './telegram-manager'
 import { getDB } from './db'
-import { getSession } from './session'
+import { getSession, getAuthSession, getInitSession } from './session'
 import { createLogger } from './logger'
 
+export const storeInitData = async (initData: string) => {
+  const session = await getInitSession()
+  if (initData !== session.initData) {
+    validateInitData(initData, getBotToken())
+  }
+  session.initData = initData
+  await session.save()
+}
+
 export const login = async (request: LoginRequest) => {
-  validateInitData(request.telegramAuth.initData, getBotToken())
-  const session = await getSession()
+  const session = await getAuthSession()
   session.spaceDID = request.spaceDID
-  session.telegramAuth = request.telegramAuth
   session.accountDID = request.accountDID
+  session.session = request.session
   await session.save()
 }
 

--- a/app/providers/telegram.tsx
+++ b/app/providers/telegram.tsx
@@ -103,7 +103,10 @@ export const Provider = ({ children }: PropsWithChildren): ReactNode => {
         console.log('Failed session token validation: ', err)
 
         const errorMsg = getErrorMessage(err)
-        if (errorMsg.includes('client authorization failed')) {
+        if (
+          errorMsg.includes('client authorization failed') ||
+          errorMsg.includes('AUTH_KEY_DUPLICATED')
+        ) {
           console.log('Session validation failed, clearing session')
           setTgSessionString('')
           setIsTgAuthorized(false)


### PR DESCRIPTION
## Description

This is three seperate small fixes:
- One for AUTH_KEY_DUPLICATED. We still don't know what is causing that, but I can see than when you receive it after a deploy trying to login, before we ever get there, there's an error in the dev console trying to validate if tg is authorized -- but then we never actually clear the session, which is what will get rid of the issue. This adds clearing the session for the same check we use for 'client unauthorized'
- One for avoiding init data expiry if you leave the app open too long. Essentially, the init data has a 24 hour expiration, and is derived from the url of the browser when you open the app (or session storage). It doesn't actually change when you login/logout -- it's the same from the minute you open the app. As a result, we cannot rely on it never being expired. The basic rule here is validate once, and if the initData doesn't change, just consider it valid. This means preserving it across login/logout, which unfortuantely does mean seperating the session cookies in two. I'm not if there's a simpler way to solve it but I couldn't find it.
- Add a tg client disconnect to the profile picture endpoint. Leaving connections open is how I think we get auth_key_duplicated. #NEVERAGAIN

## Checklist
- [x] I verified the change locally (builds and app functionality)
- [x] I ran linting and formatting commands
- [x] I acknowledge that if changes are requested and I don’t respond within 10 days, this PR may be marked stale and closed after an additional 4 days. I can ask to reopen or open a new PR later.
- [x] I have read and agree to follow the [Contribution Guidelines](../CONTRIBUTING.md)
- [x] I have added screenshots or screen captures demonstrating any new visual elements or UI

## Notes for Reviewers (optional)
<!-- Anything specific you want feedback on, or that reviewers should know? -->