### PR TITLE
feat: add graceful shutdown for ECS SIGTERM

### DIFF
--- a/app/app/api/jobs/route.ts
+++ b/app/app/api/jobs/route.ts
@@ -14,9 +14,10 @@ function isJobAuthed(request: Request) {
 
     const encodedCreds = header.split(' ')[1]
     if (!encodedCreds) return false
-    const [username, password] = Buffer.from(encodedCreds, 'base64')
+    const [username, ...passwordparts] = Buffer.from(encodedCreds, 'base64')
       .toString()
       .split(':')
+    const password = passwordparts.join(':')
     return username === 'user' && password === process.env.BACKUP_PASSWORD
   } else {
     console.warn(

--- a/app/components/server.ts
+++ b/app/components/server.ts
@@ -62,7 +62,7 @@ const sqsQueueFn = () => {
   }
 }
 
-const queueFn = queueURL ? sqsQueueFn() : localQueueFn()
+export const queueFn = queueURL ? sqsQueueFn() : localQueueFn()
 
 export const login = toResultFn(jobsLoginJob)
 export const storeInitData = toResultFn(jobsStoreInitData)

--- a/app/components/server.ts
+++ b/app/components/server.ts
@@ -1,20 +1,19 @@
 'use server'
 
-import { after } from 'next/server'
 import {
   CreateJobRequest,
   DialogInfo,
-  ExecuteJobRequest,
   Job,
   LeaderboardUser,
   Ranking,
 } from '@/api'
 import { getTelegramClient } from '@/lib/server/telegram-manager'
 import { TelegramClient, Api } from 'telegram'
-import { cleanUndef, getInitials, stringifyWithUIntArrays } from '@/lib/utils'
+import { cleanUndef, getInitials } from '@/lib/utils'
 import { getDB } from '@/lib/server/db'
 import { toResultFn } from '@/lib/errorhandling'
-import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs'
+import { queueFn } from '@/lib/server/queue'
+
 import {
   storeInitData as jobsStoreInitData,
   login as jobsLoginJob,
@@ -34,35 +33,6 @@ const names = supervillains
   .map((value) => ({ value, sort: Math.random() }))
   .sort((a, b) => a.sort - b.sort)
   .map(({ value }) => value)
-
-const queueURL = process.env.JOBS_QUEUE_ID
-
-const localQueueFn = () => {
-  return async (jr: ExecuteJobRequest) => {
-    after(async () => {
-      console.log('initiate job', jr.jobID)
-      fetch(process.env.LOCAL_URL + '/api/jobs', {
-        method: 'POST',
-        body: JSON.stringify({ body: stringifyWithUIntArrays(jr) }),
-      })
-    })
-  }
-}
-
-const sqsQueueFn = () => {
-  console.debug('creating message for sqs queue id: ', queueURL)
-  const client = new SQSClient({})
-
-  return async (jr: ExecuteJobRequest) => {
-    const command = new SendMessageCommand({
-      QueueUrl: queueURL,
-      MessageBody: stringifyWithUIntArrays(jr),
-    })
-    await client.send(command)
-  }
-}
-
-export const queueFn = queueURL ? sqsQueueFn() : localQueueFn()
 
 export const login = toResultFn(jobsLoginJob)
 export const storeInitData = toResultFn(jobsStoreInitData)

--- a/app/lib/server/graceful-shutdown.ts
+++ b/app/lib/server/graceful-shutdown.ts
@@ -1,7 +1,7 @@
 import { ExecuteJobRequest, Job } from '@/api'
 import { getDB } from './db'
 import { createLogger } from './logger'
-import { queueFn } from '@/components/server'
+import { queueFn } from '@/lib/server/queue'
 import pMap from 'p-map'
 
 const logger = createLogger({ module: 'graceful-shutdown' })

--- a/app/lib/server/graceful-shutdown.ts
+++ b/app/lib/server/graceful-shutdown.ts
@@ -1,0 +1,83 @@
+import { ExecuteJobRequest, Job } from '@/api'
+import { getDB } from './db'
+import { createLogger } from './logger'
+import { queueFn } from '@/components/server'
+
+const logger = createLogger({ module: 'graceful-shutdown' })
+
+export class GracefulShutdownManager {
+  private isShuttingDown = false
+  private activeJobs = new Map<string, ExecuteJobRequest>()
+  private shutdownPromise?: Promise<void>
+
+  constructor() {
+    process.on('SIGTERM', () => this.initiateShutdown()) // Listen for SIGTERM from ECS
+    process.on('SIGINT', () => this.initiateShutdown())
+  }
+
+  isShutdownInitiated(): boolean {
+    return this.isShuttingDown
+  }
+
+  registerActiveJob(jobRequest: ExecuteJobRequest) {
+    this.activeJobs.set(jobRequest.jobID, jobRequest)
+  }
+
+  unregisterActiveJob(jobId: string) {
+    this.activeJobs.delete(jobId)
+  }
+
+  private async initiateShutdown() {
+    if (this.isShuttingDown) return this.shutdownPromise
+
+    this.isShuttingDown = true
+    logger.info('Graceful shutdown initiated', {
+      activeJobCount: this.activeJobs.size,
+    })
+
+    this.shutdownPromise = this.performShutdown()
+    return this.shutdownPromise
+  }
+
+  private async performShutdown() {
+    try {
+      logger.info('Stopping acceptance of new job requests') //  the jobs/route endpoint will reject new requests
+
+      await this.requeueActiveJobs()
+      await this.disconnectTelegramClients()
+
+      logger.info('Graceful shutdown completed successfully')
+    } catch (error) {
+      logger.error('Error during graceful shutdown', { error })
+    } finally {
+      process.exit(0)
+    }
+  }
+
+  private async requeueActiveJobs() {
+    const db = getDB()
+
+    for (const [jobId, jobRequest] of this.activeJobs) {
+      try {
+        logger.info('Requeuing active job', { jobId })
+
+        await queueFn(jobRequest)
+
+        await db.updateJob(jobId, {
+          status: 'queued',
+          updated: Date.now(),
+        } as Job) // this also sets the progress and startedAt to null
+      } catch (error) {
+        logger.error('Failed to requeue job', { jobId, error })
+      }
+    }
+  }
+
+  private async disconnectTelegramClients() {
+    // TODO: Implement telegram client cleanup
+    // need to track active telegram connections and disconnect them
+    logger.info('Disconnecting Telegram clients')
+  }
+}
+
+export const gracefulShutdown = new GracefulShutdownManager()

--- a/app/lib/server/handler.ts
+++ b/app/lib/server/handler.ts
@@ -70,7 +70,7 @@ class Handler {
         console.log('telegram client disconnected')
       }
     }
-    gracefulShutdown.registerActiveJob(request, telegramCleanup)
+    await gracefulShutdown.registerActiveJob(request, telegramCleanup)
 
     const job = await this.#db.getJobByID(request.jobID, this.#dbUser.id)
     if (!job) throw new Error(`job not found: ${request.jobID}`)
@@ -416,7 +416,7 @@ class Handler {
         })
       }
     } finally {
-      gracefulShutdown.unregisterActiveJob(request.jobID)
+      await gracefulShutdown.unregisterActiveJob(request.jobID)
     }
   }
 

--- a/app/lib/server/handler.ts
+++ b/app/lib/server/handler.ts
@@ -66,7 +66,8 @@ class Handler {
 
     const telegramCleanup = async () => {
       if (this.telegram) {
-        await this.telegram.disconnect()
+        await this.telegram.destroy()
+        console.log('telegram client disconnected')
       }
     }
     gracefulShutdown.registerActiveJob(request, telegramCleanup)

--- a/app/lib/server/handler.ts
+++ b/app/lib/server/handler.ts
@@ -64,7 +64,12 @@ class Handler {
       throw new Error('Server is shutting down, job will be requeued')
     }
 
-    gracefulShutdown.registerActiveJob(request)
+    const telegramCleanup = async () => {
+      if (this.telegram) {
+        await this.telegram.disconnect()
+      }
+    }
+    gracefulShutdown.registerActiveJob(request, telegramCleanup)
 
     const job = await this.#db.getJobByID(request.jobID, this.#dbUser.id)
     if (!job) throw new Error(`job not found: ${request.jobID}`)

--- a/app/lib/server/queue.ts
+++ b/app/lib/server/queue.ts
@@ -6,6 +6,7 @@ import { ExecuteJobRequest } from '@/api'
 const queueURL = process.env.JOBS_QUEUE_ID
 
 const localQueueFn = () => {
+  console.debug('creating message for local queue...')
   return async (jr: ExecuteJobRequest) => {
     after(async () => {
       console.log('initiate job', jr.jobID)
@@ -26,7 +27,8 @@ const sqsQueueFn = () => {
       QueueUrl: queueURL,
       MessageBody: stringifyWithUIntArrays(jr),
     })
-    await client.send(command)
+    const result = await client.send(command)
+    console.log('SQS message sent successfully:', result.MessageId)
   }
 }
 

--- a/app/lib/server/queue.ts
+++ b/app/lib/server/queue.ts
@@ -1,0 +1,33 @@
+import { after } from 'next/server'
+import { SendMessageCommand, SQSClient } from '@aws-sdk/client-sqs'
+import { stringifyWithUIntArrays } from '@/lib/utils'
+import { ExecuteJobRequest } from '@/api'
+
+const queueURL = process.env.JOBS_QUEUE_ID
+
+const localQueueFn = () => {
+  return async (jr: ExecuteJobRequest) => {
+    after(async () => {
+      console.log('initiate job', jr.jobID)
+      fetch(process.env.LOCAL_URL + '/api/jobs', {
+        method: 'POST',
+        body: JSON.stringify({ body: stringifyWithUIntArrays(jr) }),
+      })
+    })
+  }
+}
+
+const sqsQueueFn = () => {
+  console.debug('creating message for sqs queue id: ', queueURL)
+  const client = new SQSClient({})
+
+  return async (jr: ExecuteJobRequest) => {
+    const command = new SendMessageCommand({
+      QueueUrl: queueURL,
+      MessageBody: stringifyWithUIntArrays(jr),
+    })
+    await client.send(command)
+  }
+}
+
+export const queueFn = queueURL ? sqsQueueFn() : localQueueFn()

--- a/app/lib/server/telegram-manager.ts
+++ b/app/lib/server/telegram-manager.ts
@@ -5,6 +5,7 @@ import {
   telegramAPIHash,
   defaultClientParams,
 } from '@/lib/server/constants'
+import { LogLevel } from 'telegram/extensions/Logger'
 
 /**
  * Override console.error globally to handle TIMEOUT errors from Telegram client
@@ -60,6 +61,8 @@ export const getTelegramClient = async (
     telegramAPIHash,
     defaultClientParams
   )
+
+  telegramClient.setLogLevel(LogLevel.ERROR)
 
   if (!(await telegramClient.connect())) {
     throw new Error('failed to connect to telegram')

--- a/app/lib/utils.ts
+++ b/app/lib/utils.ts
@@ -139,35 +139,45 @@ export const getInitials = (name: string) => {
 }
 
 export function stringifyWithUIntArrays(obj: unknown): string {
-  return JSON.stringify(obj, (_, value) => {
-    if (value instanceof Uint8Array) {
-      return {
-        __typedarray__: true,
-        type: value.constructor.name,
-        data: Array.from(value),
+  try {
+    return JSON.stringify(obj, (_, value) => {
+      if (value instanceof Uint8Array) {
+        return {
+          __typedarray__: true,
+          type: value.constructor.name,
+          data: Array.from(value),
+        }
       }
-    }
-    return value
-  })
+      return value
+    })
+  } catch (error) {
+    console.error('Error serializing object:', error)
+    throw new Error('Failed to serialize object', { cause: error })
+  }
 }
 
 export function parseWithUIntArrays(str: string): unknown {
-  return JSON.parse(str, (_, value) => {
-    if (
-      value &&
-      value.__typedarray__ &&
-      typeof value.type === 'string' &&
-      Array.isArray(value.data)
-    ) {
-      switch (value.type) {
-        case 'Uint8Array':
-          return new Uint8Array(value.data)
-        default:
-          return value
+  try {
+    return JSON.parse(str, (_, value) => {
+      if (
+        value &&
+        value.__typedarray__ &&
+        typeof value.type === 'string' &&
+        Array.isArray(value.data)
+      ) {
+        switch (value.type) {
+          case 'Uint8Array':
+            return new Uint8Array(value.data)
+          default:
+            return value
+        }
       }
-    }
-    return value
-  })
+      return value
+    })
+  } catch (error) {
+    console.error('Error parsing object:', error)
+    throw new Error('Failed to parse object', { cause: error })
+  }
 }
 
 export const startOfMonth = (now: string | number | Date) => {

--- a/deploy/app/main.tf
+++ b/deploy/app/main.tf
@@ -108,3 +108,26 @@ module "app" {
   env_files = var.env_files
   domain_base = var.domain_base
 }
+
+
+data "aws_iam_policy_document" "task_protection" {
+  statement {
+    effect = "Allow"
+    resources = ["*"]
+    actions = [        
+      "ecs:UpdateTaskProtection",
+      "ecs:GetTaskProtection"
+    ]
+  }
+}
+
+resource "aws_iam_policy" "task_protection" {
+  name        = "${terraform.workspace}-${var.app}-task-protection-policy"
+  description = "Policy for the task protection role"
+  policy      = data.aws_iam_policy_document.task_protection.json
+}
+
+resource "aws_iam_role_policy_attachment" "task_protection" {
+  role       = "${terraform.workspace}-${var.app}-task-role"
+  policy_arn = aws_iam_policy.task_protection.arn
+}


### PR DESCRIPTION
## Description

- Added `GracefulShutdownManager`:
  - Catches `SIGTERM` and initiates a shutdown sequence
  - Tracks running job IDs in-memory (`activeJobs`)
  - Requeues active jobs:
    - Sends them back to SQS
    - Updates DB status to `queued` (clears `started`/`progress` fields)

- Jobs Route:
  - Rejects new job submissions during shutdown
  - Responds with **503 Service Unavailable** and `Retry-After: 30s`

- Job Handler:
  - Checks if shutdown has been initiated before handling new jobs
  - Registers jobs when they start and deregisters them when they finish
  
  obs.: I still need to test it


## Checklist
- [x] I verified the change locally (builds and app functionality)
- [x] I ran linting and formatting commands
- [x] I acknowledge that if changes are requested and I don’t respond within 10 days, this PR may be marked stale and closed after an additional 4 days. I can ask to reopen or open a new PR later.
- [x] I have read and agree to follow the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] I have added screenshots or screen captures demonstrating any new visual elements or UI

## Notes for Reviewers (optional)
<!-- Anything specific you want feedback on, or that reviewers should know? -->