### PR TITLE
fix: handle job queue errors and add missing UTM param to Plausible

### DIFF
--- a/app/components/telegram-auth.tsx
+++ b/app/components/telegram-auth.tsx
@@ -343,6 +343,7 @@ export default function TelegramAuth() {
       }
       setTgSessionString(client.session)
       setIsTgAuthorized(true)
+      logTelegramLoginSuccess()
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
     } catch (err: any) {
       console.error('checking password:', err)

--- a/app/lib/analytics.ts
+++ b/app/lib/analytics.ts
@@ -37,6 +37,7 @@ const utms = [
   'utm_content',
   'utm_term',
   'utm_content',
+  'utm_campaign',
 ]
 
 /**
@@ -67,16 +68,13 @@ export const useAnalytics = () => {
     Record<string, string>
   >('utms', { defaultValue: {} })
   useEffect(() => {
-    const utmps = utms.reduce(
-      (m, utm) => {
-        const value = searchParams.get(utm)
-        if (value) {
-          m[utm] = value
-        }
-        return m
-      },
-      {} as Record<string, string>
-    )
+    const utmps = utms.reduce((m, utm) => {
+      const value = searchParams.get(utm)
+      if (value) {
+        m[utm] = value
+      }
+      return m
+    }, {} as Record<string, string>)
     if (Object.keys(utmps).length > 0) {
       setUtmParams(utmps)
     }

--- a/app/lib/store/jobs.ts
+++ b/app/lib/store/jobs.ts
@@ -87,11 +87,13 @@ class Store extends EventTarget implements JobStorage {
 
   async add(dialogs: DialogsById, period: Period) {
     console.debug('job store adding job...')
+
+    const space = this.#storacha.currentSpace()
+    if (!space) {
+      throw new Error('No space was found!')
+    }
+
     try {
-      const space = this.#storacha.currentSpace()
-      if (!space) {
-        throw new Error('No space found. Try again.')
-      }
       // check if the user has enough storage space
       const amountOfStorageUsed = await getStorachaUsage(
         this.#storacha,
@@ -100,7 +102,9 @@ class Store extends EventTarget implements JobStorage {
 
       if (await isStorageLimitExceeded(this.#storacha, amountOfStorageUsed)) {
         throw new Error(
-          `You have reached your ${formatBytes(MAX_FREE_BYTES)} free storage limit. Upgrade your account`
+          `You have reached your ${formatBytes(
+            MAX_FREE_BYTES
+          )} free storage limit. Upgrade your account`
         )
       }
     } catch (err) {


### PR DESCRIPTION
## Description
- Handle errors when adding jobs to the queue by marking them as failed in the DB
- Add the missing `utm_campaign` parameter to Plausible analytics integration

## Checklist
- [x] I verified the change locally (builds and app functionality)
- [x] I ran linting and formatting commands
- [x] I acknowledge that if changes are requested and I don’t respond within 10 days, this PR may be marked stale and closed after an additional 4 days. I can ask to reopen or open a new PR later.
- [x] I have read and agree to follow the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] I have added screenshots or screen captures demonstrating any new visual elements or UI

## Notes for Reviewers (optional)
<!-- Anything specific you want feedback on, or that reviewers should know? -->