### PR TITLE
fix: missing getServerSnapshot

### DIFF
--- a/app/app/layout.tsx
+++ b/app/app/layout.tsx
@@ -2,8 +2,7 @@ import type { Metadata } from 'next'
 import { Epilogue } from 'next/font/google'
 import PlausibleProvider from 'next-plausible'
 import './globals.css'
-import { Root } from '../components/root'
-import { AppOpenedTracker } from '../components/AppOpenedTracker'
+import { RootLoader } from '../components/root-loader'
 
 const epilogue = Epilogue({
   subsets: ['latin'],
@@ -30,10 +29,7 @@ export default function RootLayout({
     >
       <html lang="en">
         <body className={epilogue.className}>
-          <Root>
-            {children}
-            <AppOpenedTracker />
-          </Root>
+          <RootLoader>{children}</RootLoader>
         </body>
       </html>
     </PlausibleProvider>

--- a/app/components/root-loader.tsx
+++ b/app/components/root-loader.tsx
@@ -1,0 +1,26 @@
+'use client'
+
+import { PropsWithChildren } from 'react'
+import { useDidMount } from '../hooks/useDidMount'
+import LogoSplash from './svgs/logo-splash'
+import { Root } from './root'
+import { AppOpenedTracker } from './AppOpenedTracker'
+
+export function RootLoader(props: PropsWithChildren) {
+  const didMount = useDidMount()
+
+  if (!didMount) {
+    return (
+      <div className="h-screen flex justify-center items-center bg-primary">
+        <LogoSplash />
+      </div>
+    )
+  }
+
+  return (
+    <Root>
+      {props.children}
+      <AppOpenedTracker />
+    </Root>
+  )
+}

--- a/app/components/root.tsx
+++ b/app/components/root.tsx
@@ -36,7 +36,6 @@ import { ErrorPage } from './error'
 import TelegramAuth from './telegram-auth'
 import LogoSplash from './svgs/logo-splash'
 import { ErrorBoundary } from './error-boundary'
-import { useDidMount } from '../hooks/useDidMount'
 
 const version = process.env.NEXT_PUBLIC_VERSION ?? '0.0.0'
 const serverDID = parseDID(process.env.NEXT_PUBLIC_SERVER_DID ?? '')
@@ -49,7 +48,6 @@ const connection = uploadServiceConnection({ id: serviceID })
 defaultHeaders['X-Client'] += ` tg-miniapp/${version.split('.')[0]}`
 
 export function Root(props: PropsWithChildren) {
-  const didMount = useDidMount()
   const [initError, setInitError] = useState<Error | null>(null)
   const [{ isTgAuthorized }] = useTelegram()
   const { isOnboarded, tgSessionString, setTgSessionString, user } = useGlobal()
@@ -76,14 +74,6 @@ export function Root(props: PropsWithChildren) {
       setTgSessionString(session)
     }
   }, [isTgAuthorized, tgSessionString, user, setTgSessionString])
-
-  if (!didMount) {
-    return (
-      <div className="h-screen flex justify-center items-center bg-primary">
-        <LogoSplash />
-      </div>
-    )
-  }
 
   if (initError) {
     return <ErrorPage error={initError} />


### PR DESCRIPTION
## Description
Fix the issue “Missing getServerSnapshot, which is required for server-rendered content. Falling back to client rendering,” as it’s consuming Sentry quota.

## Checklist
- [x] I verified the change locally (builds and app functionality)
- [x] I ran linting and formatting commands
- [x] I acknowledge that if changes are requested and I don’t respond within 10 days, this PR may be marked stale and closed after an additional 4 days. I can ask to reopen or open a new PR later.
- [x] I have read and agree to follow the [Contribution Guidelines](../CONTRIBUTING.md)
- [ ] I have added screenshots or screen captures demonstrating any new visual elements or UI

## Notes for Reviewers (optional)
<!-- Anything specific you want feedback on, or that reviewers should know? -->